### PR TITLE
Compile Docker image with CGO enabled

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /build
 
 COPY . .
 
-RUN CGO_ENABLED=0 go build -ldflags="-s -w"
+RUN go build -ldflags="-s -w"
 
 FROM scratch
 


### PR DESCRIPTION
It required by go-sqlite3 dependency.

pacoloco    | prefetch.go:67: Binary was compiled with 'CGO_ENABLED=0', go-sqlite3 requires cgo to work. This is a stub
pacoloco exited with code 1

Closes #33