### PR TITLE
Make Dockerfile work with go-sqlite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
-FROM golang:latest as build
+FROM golang:alpine3.13 as build
+
+RUN apk add gcc libc-dev
 
 WORKDIR /build
 
 COPY . .
 
-RUN CGO_ENABLED=0 go build -ldflags="-s -w"
+RUN go build -ldflags="-s -w"
 
-FROM scratch
+FROM alpine:3.13
 
 WORKDIR /pacoloco
 


### PR DESCRIPTION
This PR switches the resulting docker image from a scratch base to alpine, which allows libraries that require CGO such as go-sqlite3 to work.
Fixes #33.
