### PR TITLE
Multiple versions prefetch fix + gzip limit

### DIFF
--- a/pacoloco.go
+++ b/pacoloco.go
@@ -36,8 +36,8 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	// source: https://archlinux.org/pacman/makepkg.conf.5.html PKGEXT section
-	allowedPackagesExtensions = []string{".pkg.tar.gz", ".pkg.tar.bz2", ".pkg.tar.xz", ".pkg.tar.zst", ".pkg.tar.lzo", ".pkg.tar.lrz", ".pkg.tar.lz4", ".pkg.tar.lz", ".pkg.tar.Z", ".pkg.tar"}
+	// source: https://archlinux.org/pacman/makepkg.conf.5.html PKGEXT section, sorted with compressed formats as first.
+	allowedPackagesExtensions = []string{".pkg.tar.zst", ".pkg.tar.gz", ".pkg.tar.xz", ".pkg.tar.bz2", ".pkg.tar.lzo", ".pkg.tar.lrz", ".pkg.tar.lz4", ".pkg.tar.lz", ".pkg.tar.Z", ".pkg.tar"}
 
 	// Filename regex explanation (also here https://regex101.com/r/qB0fQ7/35 )
 	/*
@@ -283,7 +283,7 @@ func handleRequest(w http.ResponseWriter, req *http.Request) error {
 		if repo.URL != "" {
 			served, err = downloadFileAndSend(repo.URL+path+"/"+fileName, filePath, ifLater, w)
 			if err == nil && config.Prefetch != nil && !strings.HasSuffix(fileName, ".sig") && !strings.HasSuffix(fileName, ".db") {
-				updateDBDownloadedFile(repoName, fileName) // update info for prefetching
+				updateDBRequestedFile(repoName, fileName) // update info for prefetching
 			} else if err == nil && config.Prefetch != nil && strings.HasSuffix(fileName, ".db") {
 				addDBfileToDB(repo.URL+path+"/"+fileName, repoName)
 			}
@@ -292,7 +292,7 @@ func handleRequest(w http.ResponseWriter, req *http.Request) error {
 				served, err = downloadFileAndSend(url+path+"/"+fileName, filePath, ifLater, w)
 				if err == nil {
 					if config.Prefetch != nil && !strings.HasSuffix(fileName, ".sig") && !strings.HasSuffix(fileName, ".db") {
-						updateDBDownloadedFile(repoName, fileName) // update info for prefetching
+						updateDBRequestedFile(repoName, fileName) // update info for prefetching
 					} else if err == nil && config.Prefetch != nil && strings.HasSuffix(fileName, ".db") {
 						addDBfileToDB(url+path+"/"+fileName, repoName)
 					}
@@ -305,7 +305,7 @@ func handleRequest(w http.ResponseWriter, req *http.Request) error {
 	if !served {
 		err = sendCachedFile(w, req, fileName, filePath)
 		if err == nil && config.Prefetch != nil && !strings.HasSuffix(fileName, ".sig") && !strings.HasSuffix(fileName, ".db") {
-			updateDBDownloadedFile(repoName, fileName) // update info for prefetching
+			updateDBRequestedFile(repoName, fileName) // update info for prefetching
 		}
 	}
 	return err

--- a/pacoloco.go
+++ b/pacoloco.go
@@ -153,7 +153,7 @@ var (
 )
 
 // force resources prefetching
-func prefetchRequest(url string) (err error) {
+func prefetchRequest(url string, optionalCustomPath string) (err error) {
 	urlPath := url
 	matches := pathRegex.FindStringSubmatch(urlPath)
 	if len(matches) == 0 {
@@ -173,7 +173,12 @@ func prefetchRequest(url string) (err error) {
 			return err
 		}
 	}
-	filePath := filepath.Join(cachePath, fileName)
+	var filePath string
+	if optionalCustomPath != "" {
+		filePath = filepath.Join(optionalCustomPath, fileName)
+	} else {
+		filePath = filepath.Join(cachePath, fileName)
+	}
 	// mandatory update when prefetching,
 
 	mutexKey := repoName + ":" + fileName
@@ -285,7 +290,7 @@ func handleRequest(w http.ResponseWriter, req *http.Request) error {
 			if err == nil && config.Prefetch != nil && !strings.HasSuffix(fileName, ".sig") && !strings.HasSuffix(fileName, ".db") {
 				updateDBRequestedFile(repoName, fileName) // update info for prefetching
 			} else if err == nil && config.Prefetch != nil && strings.HasSuffix(fileName, ".db") {
-				addDBfileToDB(repo.URL+path+"/"+fileName, repoName)
+				updateDBRequestedDB(repoName, path, fileName)
 			}
 		} else {
 			for _, url := range repo.URLs {
@@ -294,7 +299,7 @@ func handleRequest(w http.ResponseWriter, req *http.Request) error {
 					if config.Prefetch != nil && !strings.HasSuffix(fileName, ".sig") && !strings.HasSuffix(fileName, ".db") {
 						updateDBRequestedFile(repoName, fileName) // update info for prefetching
 					} else if err == nil && config.Prefetch != nil && strings.HasSuffix(fileName, ".db") {
-						addDBfileToDB(url+path+"/"+fileName, repoName)
+						updateDBRequestedDB(repoName, path, fileName)
 					}
 					break
 				}

--- a/prefetch.go
+++ b/prefetch.go
@@ -70,7 +70,7 @@ func setupPrefetch() {
 }
 
 // function to update the db when a package is being actively requested
-func updateDBDownloadedFile(repoName string, fileName string) {
+func updateDBRequestedFile(repoName string, fileName string) {
 	// don't register when signature gets downloaded, to reduce db accesses
 	if !strings.HasSuffix(fileName, ".sig") && !strings.HasSuffix(fileName, ".db") {
 		pkg, err := getPackageFromFilenameAndRepo(repoName, fileName)
@@ -164,7 +164,7 @@ func updateDBPrefetchedFile(repoName string, fileName string) {
 // purges all possible package files
 func purgePkgIfExists(pkgToDel *Package) {
 	if pkgToDel != nil {
-		basePathsToDelete := getPackagePaths(*pkgToDel)
+		basePathsToDelete := getAllPackagePaths(*pkgToDel)
 		for _, p := range basePathsToDelete {
 			pathToDelete := path.Join(config.CacheDir, p)
 			if _, err := os.Stat(pathToDelete); !os.IsNotExist(err) {
@@ -227,7 +227,7 @@ func cleanPrefetchDB() {
 		}
 
 		// should be useless but this guarantees that everything got cleaned properly
-		_ = deleteRepoTable()
+		_ = deleteMirrorPkgsTable()
 		log.Printf("Db cleaned.\n")
 	} else {
 		log.Fatalf("Shouldn't call a prefetch purge when prefetch is not set in the yaml. This is most likely a bug.")
@@ -237,7 +237,7 @@ func cleanPrefetchDB() {
 // This calls the actual prefetching process, should be called once the db had been cleaned
 func prefetchAllPkgs() {
 	updateMirrorsDbs()
-	defer deleteRepoTable()
+	defer deleteMirrorPkgsTable()
 	pkgs := getPkgsToUpdate()
 	for _, p := range pkgs {
 		pkg := getPackage(p.PackageName, p.Arch, p.RepoName)

--- a/repo_db_mirror_test.go
+++ b/repo_db_mirror_test.go
@@ -11,7 +11,6 @@ import (
 	"path"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -312,43 +311,5 @@ func TestBuildMirrorPkg(t *testing.T) {
 	}
 	if _, err = buildMirrorPkg("webkit2gtk-2.26.4-1-x86_6-4.pkg.tar.zst", "testRepo", ""); err == nil {
 		t.Errorf("Should have thrown an error cause the string is invalid")
-	}
-}
-
-func TestGetPrefixFromMirrorDB(t *testing.T) {
-	testSetupHelper(t)
-	setupPrefetch()
-	now := time.Now()
-	testMirror := MirrorDB{URL: "https://mirror.example.com/mirror/packages/archlinux//extra/os/x86_64/extra.db", RepoName: "example", LastTimeDownloaded: &now}
-	got, err := getPrefixFromMirrorDB(testMirror)
-	if err != nil {
-		t.Errorf("%v", err)
-	}
-	want := "/extra/os/x86_64/"
-	if !cmp.Equal(got, want) {
-		t.Errorf("Got %v, want %v", got, want)
-	}
-	testMirror = MirrorDB{URL: "https://mirror.example.com/mirror/packages/archlinux/extra//os/x86_64/extra.db", RepoName: "example", LastTimeDownloaded: &now}
-	got, err = getPrefixFromMirrorDB(testMirror)
-	if err != nil {
-		t.Errorf("%v", err)
-	}
-	want = "/extra//os/x86_64/"
-	if !cmp.Equal(got, want) {
-		t.Errorf("Got %v, want %v", got, want)
-	}
-	testMirror = MirrorDB{URL: "https://mirror.example.com/mirror/packages/archlinux/extra.db", RepoName: "example", LastTimeDownloaded: &now}
-	got, err = getPrefixFromMirrorDB(testMirror)
-	if err != nil {
-		t.Errorf("%v", err)
-	}
-	want = ""
-	if !cmp.Equal(got, want) {
-		t.Errorf("Got %v, want %v", got, want)
-	}
-	testMirror = MirrorDB{URL: "https://mirror.example.com/mirror/packagesarchlinux/extra.db", RepoName: "example", LastTimeDownloaded: &now}
-	_, err = getPrefixFromMirrorDB(testMirror)
-	if err == nil {
-		t.Errorf("Should have raised error")
 	}
 }

--- a/repo_db_mirror_test.go
+++ b/repo_db_mirror_test.go
@@ -261,16 +261,16 @@ func TestGetPacolocoURL(t *testing.T) {
 	}
 }
 
-func TestBuildRepoPkg(t *testing.T) {
-	got, err := buildRepoPkg("libstdc++5-3.3.6-7-x86_64.pkg.tar.zst", "testRepo", "community")
+func TestBuildMirrorPkg(t *testing.T) {
+	got, err := buildMirrorPkg("libstdc++5-3.3.6-7-x86_64.pkg.tar.zst", "testRepo", "community")
 	if err != nil {
 		log.Fatal(err)
 	}
-	want := RepoPackage{PackageName: "libstdc++5", RepoName: "testRepo", Version: "3.3.6-7", Arch: "x86_64", DownloadURL: "/repo/testRepo/community/libstdc++5-3.3.6-7-x86_64"}
+	want := MirrorPackage{PackageName: "libstdc++5", RepoName: "testRepo", Version: "3.3.6-7", Arch: "x86_64", DownloadURL: "/repo/testRepo/community/libstdc++5-3.3.6-7-x86_64", FileExt: ".pkg.tar.zst"}
 	if !cmp.Equal(got, want) {
 		t.Errorf("Got %v, want %v", got, want)
 	}
-	if _, err = buildRepoPkg("webkit2gtk-2.26.4-1-x86_6-4.pkg.tar.zst", "testRepo", ""); err == nil {
+	if _, err = buildMirrorPkg("webkit2gtk-2.26.4-1-x86_6-4.pkg.tar.zst", "testRepo", ""); err == nil {
 		t.Errorf("Should have thrown an error cause the string is invalid")
 	}
 }


### PR DESCRIPTION
This should fix the multiple extension issue #37 and the todo for the gzip db files, which their extraction size was unrestricted and could have caused a DoS by exhausting the storage size if a mirror would have served a gzip bomb rather than a proper db file.
I had also refactored some code because I didn't properly named some functions and structs (I did some confusion between repo and mirrors).