### PR TITLE
Build and publish docker images to ghcr.io

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: macbre/push-to-ghcr@master
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/master' }}
         with:
           image_name: ${{ github.repository }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: '^1.17.13'
+          cache: true
 
       - name: Run tests
         run: go test

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -22,7 +22,9 @@ jobs:
       - name: Build
         run: go build
 
-  build:
+  publish_latest:
+    if: github.ref == 'refs/heads/master'
+
     runs-on: ubuntu-latest
     needs:
       - test
@@ -30,9 +32,27 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: macbre/push-to-ghcr@master
-        if: ${{ github.ref == 'refs/heads/master' }}
+      - name: publish master to latest
+        uses: macbre/push-to-ghcr@master
         with:
           image_name: ${{ github.repository }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          # tag: # TODO: publish release tags
+          tag: latest
+
+  publish_release:
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    runs-on: ubuntu-latest
+
+    needs:
+      - test
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: publish master to latest
+        uses: macbre/push-to-ghcr@master
+        with:
+          image_name: ${{ github.repository }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref_name}}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,0 +1,38 @@
+---
+name: Build and push to ghcr.io
+
+on:
+  workflow_dispatch:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '^1.17.13'
+
+      - name: Run tests
+        run: go test
+
+      - name: Build
+        run: go build
+
+  build:
+    runs-on: ubuntu-latest
+    needs:
+      - test
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: macbre/push-to-ghcr@master
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          image_name: ${{ github.repository }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # tag: # TODO: publish release tags

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           image_name: ${{ github.repository }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: latest
+          image_tag: latest
 
   publish_release:
     if: startsWith(github.ref, 'refs/tags/v')
@@ -50,9 +50,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: publish master to latest
+      - name: publish release to tag
         uses: macbre/push-to-ghcr@master
         with:
           image_name: ${{ github.repository }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ github.ref_name}}
+          image_tag: ${{ github.ref_name }}


### PR DESCRIPTION
Addresses https://github.com/anatol/pacoloco/issues/59

Changes:
- Add a github workflow that runs tests, builds and publishes a docker image to ghcr.io

publishing to a docker registry makes it possible to deploy pacoloco in kubernetes or using docker-compose without building the app manually.

ghcr.io is the simplest way for publishing a docker image if the code is hosted on github, almost zero configuration needed.

Currently only amd64 is supported.

Please consider using releases instead of tags and don't forget to enable pushing to ghcr in repo's settings

Questions:
- Get rid of travis?