### PR TITLE
Add `restart` to docker-compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ services:
     volumes:
       - /path/to/cache:/var/cache/pacoloco
       - /path/to/config/pacoloco.yaml:/etc/pacoloco.yaml
+    restart: unless-stopped
 ```
 
 ## Build from sources


### PR DESCRIPTION
my container quit unexpectedly tonight. this works around that but is also a reasonable default imo.