### PR TITLE
Soft failure on prefetch (#64)

### DIFF
--- a/prefetch.go
+++ b/prefetch.go
@@ -224,7 +224,11 @@ func cleanPrefetchDB() {
 func prefetchAllPkgs() {
 	updateMirrorsDbs()
 	defer deleteMirrorPkgsTable()
-	pkgs := getPkgsToUpdate()
+	pkgs, err := getPkgsToUpdate()
+	if err != nil {
+		log.Printf("Prefetching failed: %v. Are you sure you had something to prefetch?", err)
+		return
+	}
 	for _, p := range pkgs {
 		pkg := getPackage(p.PackageName, p.Arch, p.RepoName)
 		urls := getPkgToUpdateDownloadURLs(p)

--- a/prefetch_db.go
+++ b/prefetch_db.go
@@ -202,18 +202,18 @@ func getPkgToUpdateDownloadURLs(p PkgToUpdate) []string {
 }
 
 // returns a list of packages which should be prefetched
-func getPkgsToUpdate() []PkgToUpdate {
+func getPkgsToUpdate() ([]PkgToUpdate, error) {
 	rows, err := prefetchDB.Model(&Package{}).Joins("inner join mirror_packages on mirror_packages.package_name = packages.package_name AND mirror_packages.arch = packages.arch AND mirror_packages.repo_name = packages.repo_name AND mirror_packages.version <> packages.version").Select("packages.package_name,packages.arch,packages.repo_name,mirror_packages.download_url,mirror_packages.file_ext").Rows()
-	if err != nil {
-		log.Fatal(err)
-	}
 	var pkgs []PkgToUpdate
+	if err != nil {
+		return pkgs, err
+	}
 	for rows.Next() {
 		var pkg PkgToUpdate
 		rows.Scan(&pkg.PackageName, &pkg.Arch, &pkg.RepoName, &pkg.DownloadURL, &pkg.FileExt)
 		pkgs = append(pkgs, pkg)
 	}
-	return pkgs
+	return pkgs, nil
 }
 
 // add a pacoloco url of a DB in a db. This urls are used to download afterwards the db to know which packages should be prefetched.

--- a/prefetch_db_test.go
+++ b/prefetch_db_test.go
@@ -241,7 +241,10 @@ func TestGetPkgsToUpdate(t *testing.T) {
 	if db := prefetchDB.Save(&repoPkg); db.Error != nil {
 		t.Error(db.Error)
 	}
-	got := getPkgsToUpdate()
+	got, err := getPkgsToUpdate()
+	if err != nil {
+		t.Fatal(err)
+	}
 	want := []PkgToUpdate{PkgToUpdate{PackageName: "webkit", RepoName: "foo", Arch: "x86_64", DownloadURL: "/repo/foo/webkit-2.4.1-1-x86_64", FileExt: ".pkg.tar.zst"}}
 	if !cmp.Equal(got, want) {
 		t.Errorf("\ngot  %v\nwant %v", got, want)


### PR DESCRIPTION
Do not throw fatal error on failed prefetch. It may happen in a very early setup if prefetch is called with no packages upstream and it should be ok.