### PR TITLE
Fix map concurrency

### DIFF
--- a/config.go
+++ b/config.go
@@ -23,7 +23,8 @@ type Repo struct {
 	Mirrorlist           string    `yaml:"mirrorlist"`
 	LastMirrorlistCheck  time.Time `yaml:"-"`
 	LastModificationTime time.Time `yaml:"-"`
-	mutex                sync.Mutex
+	timestampsMutex      sync.Mutex
+	urlsMutex            sync.RWMutex
 }
 
 type RefreshPeriod struct {

--- a/config.go
+++ b/config.go
@@ -3,6 +3,8 @@ package main
 import (
 	"log"
 	"os/user"
+	"sync"
+	"time"
 
 	"github.com/gorhill/cronexpr"
 	"golang.org/x/sys/unix"
@@ -16,9 +18,12 @@ const DefaultTTLUnupdated = 200
 const DefaultDBName = "sqlite-pkg-cache.db"
 
 type Repo struct {
-	URL        string   `yaml:"url"`
-	URLs       []string `yaml:"urls"`
-	Mirrorlist string   `yaml:"mirrorlist"`
+	URL                  string   `yaml:"url"`
+	URLs                 []string `yaml:"urls"`
+	Mirrorlist           string   `yaml:"mirrorlist"`
+	mutex                sync.RWMutex
+	lastMirrorlistCheck  time.Time
+	lastModificationTime time.Time
 }
 
 type RefreshPeriod struct {
@@ -28,15 +33,15 @@ type RefreshPeriod struct {
 }
 
 type Config struct {
-	CacheDir        string          `yaml:"cache_dir"`
-	Port            int             `yaml:"port"`
-	Repos           map[string]Repo `yaml:"repos,omitempty"`
-	PurgeFilesAfter int             `yaml:"purge_files_after"`
-	DownloadTimeout int             `yaml:"download_timeout"`
-	Prefetch        *RefreshPeriod  `yaml:"prefetch"`
-	HttpProxy       string          `yaml:"http_proxy"`
-	UserAgent       string          `yaml:"user_agent"`
-	LogTimestamp    bool            `yaml:"set_timestamp_to_logs"`
+	CacheDir        string           `yaml:"cache_dir"`
+	Port            int              `yaml:"port"`
+	Repos           map[string]*Repo `yaml:"repos,omitempty"`
+	PurgeFilesAfter int              `yaml:"purge_files_after"`
+	DownloadTimeout int              `yaml:"download_timeout"`
+	Prefetch        *RefreshPeriod   `yaml:"prefetch"`
+	HttpProxy       string           `yaml:"http_proxy"`
+	UserAgent       string           `yaml:"user_agent"`
+	LogTimestamp    bool             `yaml:"set_timestamp_to_logs"`
 }
 
 var config *Config

--- a/config.go
+++ b/config.go
@@ -18,12 +18,12 @@ const DefaultTTLUnupdated = 200
 const DefaultDBName = "sqlite-pkg-cache.db"
 
 type Repo struct {
-	URL                  string   `yaml:"url"`
-	URLs                 []string `yaml:"urls"`
-	Mirrorlist           string   `yaml:"mirrorlist"`
-	mutex                sync.Mutex
-	lastMirrorlistCheck  time.Time
-	lastModificationTime time.Time
+	URL                  string     `yaml:"url"`
+	URLs                 []string   `yaml:"urls"`
+	Mirrorlist           string     `yaml:"mirrorlist"`
+	Mutex                sync.Mutex `yaml:"-"`
+	LastMirrorlistCheck  time.Time  `yaml:"-"`
+	LastModificationTime time.Time  `yaml:"-"`
 }
 
 type RefreshPeriod struct {

--- a/config.go
+++ b/config.go
@@ -18,12 +18,12 @@ const DefaultTTLUnupdated = 200
 const DefaultDBName = "sqlite-pkg-cache.db"
 
 type Repo struct {
-	URL                  string     `yaml:"url"`
-	URLs                 []string   `yaml:"urls"`
-	Mirrorlist           string     `yaml:"mirrorlist"`
-	Mutex                sync.Mutex `yaml:"-"`
-	LastMirrorlistCheck  time.Time  `yaml:"-"`
-	LastModificationTime time.Time  `yaml:"-"`
+	URL                  string    `yaml:"url"`
+	URLs                 []string  `yaml:"urls"`
+	Mirrorlist           string    `yaml:"mirrorlist"`
+	LastMirrorlistCheck  time.Time `yaml:"-"`
+	LastModificationTime time.Time `yaml:"-"`
+	mutex                sync.Mutex
 }
 
 type RefreshPeriod struct {

--- a/config.go
+++ b/config.go
@@ -21,7 +21,7 @@ type Repo struct {
 	URL                  string   `yaml:"url"`
 	URLs                 []string `yaml:"urls"`
 	Mirrorlist           string   `yaml:"mirrorlist"`
-	mutex                sync.RWMutex
+	mutex                sync.Mutex
 	lastMirrorlistCheck  time.Time
 	lastModificationTime time.Time
 }

--- a/config_test.go
+++ b/config_test.go
@@ -57,7 +57,7 @@ repos:
 		DownloadTimeout: 200,
 		Prefetch:        &RefreshPeriod{Cron: "0 0 3 * * * *", TTLUnaccessed: 5, TTLUnupdated: 200},
 	}
-	if !cmp.Equal(*got, *want, cmpopts.IgnoreFields(Config{}, "Prefetch"), cmpopts.IgnoreFields(Repo{}, "Mutex")) {
+	if !cmp.Equal(*got, *want, cmpopts.IgnoreFields(Config{}, "Prefetch"), cmpopts.IgnoreFields(Repo{}, "mutex")) {
 		t.Errorf("got %v, want %v", *got, *want)
 	}
 	gotR := *(*got).Prefetch
@@ -154,12 +154,36 @@ repos:
 		DownloadTimeout: 200,
 		Prefetch:        &RefreshPeriod{Cron: "0 0 3 * * * *", TTLUnaccessed: 5, TTLUnupdated: 200},
 	}
-	if !cmp.Equal(*got, *want, cmpopts.IgnoreFields(Config{}, "Prefetch"), cmpopts.IgnoreFields(Repo{}, "Mutex")) {
+	if !cmp.Equal(*got, *want, cmpopts.IgnoreFields(Config{}, "Prefetch"), cmpopts.IgnoreFields(Repo{}, "mutex")) {
 		t.Errorf("got %v, want %v", *got, *want)
 	}
 	gotR := *(*got).Prefetch
 	wantR := *(*want).Prefetch
 	if !cmp.Equal(gotR, wantR) {
 		t.Errorf("got %v, want %v", gotR, wantR)
+	}
+}
+
+func TestLoadConfigWithMirrorlistTimestamps(t *testing.T) {
+	got := parseConfig([]byte(`
+cache_dir: /tmp
+repos:
+  archlinux:
+    url: http://mirrors.kernel.org/archlinux
+    # these fields *shouldn't* be unmarshalled
+    lastmirrorlistcheck: 2
+    lastmodificationtime: 2
+`))
+	want := &Config{
+		CacheDir: "/tmp",
+		Port:     DefaultPort,
+		Repos: map[string]*Repo{
+			"archlinux": &Repo{
+				URL: "http://mirrors.kernel.org/archlinux",
+			},
+		},
+	}
+	if !cmp.Equal(*got, *want, cmpopts.IgnoreFields(Repo{}, "mutex")) {
+		t.Errorf("got %v, want %v", *got, *want)
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -57,7 +57,7 @@ repos:
 		DownloadTimeout: 200,
 		Prefetch:        &RefreshPeriod{Cron: "0 0 3 * * * *", TTLUnaccessed: 5, TTLUnupdated: 200},
 	}
-	if !cmp.Equal(*got, *want, cmpopts.IgnoreFields(Config{}, "Prefetch"), cmpopts.IgnoreFields(Repo{}, "mutex")) {
+	if !cmp.Equal(*got, *want, cmpopts.IgnoreFields(Config{}, "Prefetch"), cmpopts.IgnoreFields(Repo{}, "timestampsMutex", "urlsMutex")) {
 		t.Errorf("got %v, want %v", *got, *want)
 	}
 	gotR := *(*got).Prefetch
@@ -154,7 +154,7 @@ repos:
 		DownloadTimeout: 200,
 		Prefetch:        &RefreshPeriod{Cron: "0 0 3 * * * *", TTLUnaccessed: 5, TTLUnupdated: 200},
 	}
-	if !cmp.Equal(*got, *want, cmpopts.IgnoreFields(Config{}, "Prefetch"), cmpopts.IgnoreFields(Repo{}, "mutex")) {
+	if !cmp.Equal(*got, *want, cmpopts.IgnoreFields(Config{}, "Prefetch"), cmpopts.IgnoreFields(Repo{}, "timestampsMutex", "urlsMutex")) {
 		t.Errorf("got %v, want %v", *got, *want)
 	}
 	gotR := *(*got).Prefetch
@@ -183,7 +183,7 @@ repos:
 			},
 		},
 	}
-	if !cmp.Equal(*got, *want, cmpopts.IgnoreFields(Repo{}, "mutex")) {
+	if !cmp.Equal(*got, *want, cmpopts.IgnoreFields(Repo{}, "timestampsMutex", "urlsMutex")) {
 		t.Errorf("got %v, want %v", *got, *want)
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -48,8 +48,8 @@ repos:
 	want := &Config{
 		CacheDir: `/tmp`,
 		Port:     9139,
-		Repos: map[string]Repo{
-			"archlinux": Repo{
+		Repos: map[string]*Repo{
+			"archlinux": &Repo{
 				URL: "http://mirrors.kernel.org/archlinux",
 			},
 		},
@@ -57,7 +57,7 @@ repos:
 		DownloadTimeout: 200,
 		Prefetch:        &RefreshPeriod{Cron: "0 0 3 * * * *", TTLUnaccessed: 5, TTLUnupdated: 200},
 	}
-	if !cmp.Equal(*got, *want, cmpopts.IgnoreFields(Config{}, "Prefetch")) {
+	if !cmp.Equal(*got, *want, cmpopts.IgnoreFields(Config{}, "Prefetch"), cmpopts.IgnoreUnexported(Repo{})) {
 		t.Errorf("got %v, want %v", *got, *want)
 	}
 	gotR := *(*got).Prefetch
@@ -79,8 +79,8 @@ repos:
 	want := &Config{
 		CacheDir: `/tmp`,
 		Port:     9129,
-		Repos: map[string]Repo{
-			"archlinux": Repo{
+		Repos: map[string]*Repo{
+			"archlinux": &Repo{
 				URL: "http://mirrors.kernel.org/archlinux",
 			},
 		},
@@ -105,8 +105,8 @@ repos:
 	want := &Config{
 		CacheDir: `/tmp`,
 		Port:     9129,
-		Repos: map[string]Repo{
-			"archlinux": Repo{
+		Repos: map[string]*Repo{
+			"archlinux": &Repo{
 				URL: "http://mirrors.kernel.org/archlinux",
 			},
 		},
@@ -145,8 +145,8 @@ repos:
 	want := &Config{
 		CacheDir: temp,
 		Port:     9139,
-		Repos: map[string]Repo{
-			"archlinux": Repo{
+		Repos: map[string]*Repo{
+			"archlinux": &Repo{
 				Mirrorlist: tmpfile,
 			},
 		},
@@ -154,7 +154,7 @@ repos:
 		DownloadTimeout: 200,
 		Prefetch:        &RefreshPeriod{Cron: "0 0 3 * * * *", TTLUnaccessed: 5, TTLUnupdated: 200},
 	}
-	if !cmp.Equal(*got, *want, cmpopts.IgnoreFields(Config{}, "Prefetch")) {
+	if !cmp.Equal(*got, *want, cmpopts.IgnoreFields(Config{}, "Prefetch"), cmpopts.IgnoreUnexported(Repo{})) {
 		t.Errorf("got %v, want %v", *got, *want)
 	}
 	gotR := *(*got).Prefetch

--- a/config_test.go
+++ b/config_test.go
@@ -57,7 +57,7 @@ repos:
 		DownloadTimeout: 200,
 		Prefetch:        &RefreshPeriod{Cron: "0 0 3 * * * *", TTLUnaccessed: 5, TTLUnupdated: 200},
 	}
-	if !cmp.Equal(*got, *want, cmpopts.IgnoreFields(Config{}, "Prefetch"), cmpopts.IgnoreUnexported(Repo{})) {
+	if !cmp.Equal(*got, *want, cmpopts.IgnoreFields(Config{}, "Prefetch"), cmpopts.IgnoreFields(Repo{}, "Mutex")) {
 		t.Errorf("got %v, want %v", *got, *want)
 	}
 	gotR := *(*got).Prefetch
@@ -154,7 +154,7 @@ repos:
 		DownloadTimeout: 200,
 		Prefetch:        &RefreshPeriod{Cron: "0 0 3 * * * *", TTLUnaccessed: 5, TTLUnupdated: 200},
 	}
-	if !cmp.Equal(*got, *want, cmpopts.IgnoreFields(Config{}, "Prefetch"), cmpopts.IgnoreUnexported(Repo{})) {
+	if !cmp.Equal(*got, *want, cmpopts.IgnoreFields(Config{}, "Prefetch"), cmpopts.IgnoreFields(Repo{}, "Mutex")) {
 		t.Errorf("got %v, want %v", *got, *want)
 	}
 	gotR := *(*got).Prefetch

--- a/integration_test.go
+++ b/integration_test.go
@@ -43,7 +43,7 @@ func TestPacolocoIntegrationWithPrefetching(t *testing.T) {
 		Port:            -1,
 		PurgeFilesAfter: -1,
 		DownloadTimeout: 999,
-		Repos:           make(map[string]Repo),
+		Repos:           make(map[string]*Repo),
 		Prefetch:        &RefreshPeriod{Cron: "0 0 " + fmt.Sprint(notInvokingPrefetchTime.Hour()) + " ? * 1#1 *"},
 	}
 	setupPrefetch()
@@ -88,7 +88,7 @@ func TestPacolocoIntegration(t *testing.T) {
 		Port:            -1,
 		PurgeFilesAfter: -1,
 		DownloadTimeout: 999,
-		Repos:           make(map[string]Repo),
+		Repos:           make(map[string]*Repo),
 		Prefetch:        nil,
 	}
 
@@ -135,7 +135,7 @@ func testRequestNonExistingDb(t *testing.T) {
 
 func testRequestExistingRepo(t *testing.T) {
 	// Requesting existing repo
-	config.Repos["repo1"] = Repo{}
+	config.Repos["repo1"] = &Repo{}
 	defer delete(config.Repos, "repo1")
 
 	req := httptest.NewRequest("GET", pacolocoURL+"/repo/repo1/test.db", nil)
@@ -154,7 +154,7 @@ func testRequestExistingRepo(t *testing.T) {
 
 func testRequestExistingRepoWithDb(t *testing.T) {
 	// Requesting existing repo
-	config.Repos["repo2"] = Repo{
+	config.Repos["repo2"] = &Repo{
 		URL: mirrorURL + "/mirror2",
 	}
 	defer delete(config.Repos, "repo2")
@@ -262,7 +262,7 @@ func testRequestExistingRepoWithDb(t *testing.T) {
 
 func testRequestPackageFile(t *testing.T) {
 	// Requesting existing repo
-	config.Repos["repo3"] = Repo{
+	config.Repos["repo3"] = &Repo{
 		URL: mirrorURL + "/mirror3",
 	}
 	defer delete(config.Repos, "repo3")
@@ -362,7 +362,7 @@ func testRequestPackageFile(t *testing.T) {
 }
 
 func testFailover(t *testing.T) {
-	config.Repos["failover"] = Repo{
+	config.Repos["failover"] = &Repo{
 		URLs: []string{mirrorURL + "/no-mirror", mirrorURL + "/mirror-failover"},
 	}
 	defer delete(config.Repos, "failover")

--- a/mirrorlist.go
+++ b/mirrorlist.go
@@ -32,8 +32,8 @@ func tryCheckAndUpdateMirrorlistRepo(repoName string, repo *Repo) error {
 		return nil
 	}
 
-	repo.mutex.Lock()
-	defer repo.mutex.Unlock()
+	repo.timestampsMutex.Lock()
+	defer repo.timestampsMutex.Unlock()
 
 	// if we checked recently then skip it
 	if time.Since(repo.LastMirrorlistCheck) < 5*time.Second {
@@ -60,6 +60,9 @@ func tryCheckAndUpdateMirrorlistRepo(repoName string, repo *Repo) error {
 		return err
 	}
 	defer file.Close()
+
+	repo.urlsMutex.Lock()
+	defer repo.urlsMutex.Unlock()
 
 	// initialize the urls collection
 	repo.URLs = make([]string, 0)

--- a/mirrorlist.go
+++ b/mirrorlist.go
@@ -20,8 +20,8 @@ func updateMirrorlists() {
 
 func checkAndUpdateMirrorlistRepo(repoName string, repo *Repo) error {
 	if repo.Mirrorlist != "" {
-		repo.Mutex.Lock()
-		defer repo.Mutex.Unlock()
+		repo.mutex.Lock()
+		defer repo.mutex.Unlock()
 
 		if time.Since(repo.LastMirrorlistCheck) < 5*time.Second {
 			// if there is an entry in the lastMirrorlistCheck and that entry has a distance lower than 5 seconds from now, don't update its mirrorlist

--- a/mirrorlist.go
+++ b/mirrorlist.go
@@ -18,51 +18,56 @@ func updateMirrorlists() {
 	}
 }
 
+// wrapper that maps errors to a consistent format.
 func checkAndUpdateMirrorlistRepo(repoName string, repo *Repo) error {
-	if repo.Mirrorlist != "" {
-		repo.mutex.Lock()
-		defer repo.mutex.Unlock()
-
-		if time.Since(repo.LastMirrorlistCheck) < 5*time.Second {
-			// if there is an entry in the lastMirrorlistCheck and that entry has a distance lower than 5 seconds from now, don't update its mirrorlist
-			return nil
-		}
-
-		repo.LastMirrorlistCheck = time.Now()
-		err := updateRepoMirrorlist(repoName, repo)
-		if err != nil {
-			return fmt.Errorf("error while updating %v repo mirrorlist: %v", repoName, err)
-		}
+	err := tryCheckAndUpdateMirrorlistRepo(repoName, repo)
+	if err != nil {
+		err = fmt.Errorf("error while updating %v repo mirrorlist: %w", repoName, err)
 	}
-	return nil
+	return err
 }
 
-func updateRepoMirrorlist(repoName string, repo *Repo) error {
+func tryCheckAndUpdateMirrorlistRepo(repoName string, repo *Repo) error {
+	if repo.Mirrorlist == "" {
+		return nil
+	}
+
+	repo.mutex.Lock()
+	defer repo.mutex.Unlock()
+
+	// if we checked recently then skip it
+	if time.Since(repo.LastMirrorlistCheck) < 5*time.Second {
+		return nil
+	}
+	repo.LastMirrorlistCheck = time.Now()
+
 	fileInfo, err := os.Stat(repo.Mirrorlist)
 	if err != nil {
 		return err
 	}
 
 	fileModTime := fileInfo.ModTime()
+	// if it hasn't been updated then skip it
 	if fileModTime == repo.LastModificationTime {
 		return nil
 	}
-
 	repo.LastModificationTime = fileModTime
 
+	// it's out of date so now update the URLs from the mirrorlist.
 	// open readonly, it won't change modification time
 	file, err := os.Open(repo.Mirrorlist)
 	if err != nil {
 		return err
 	}
 	defer file.Close()
+
 	// initialize the urls collection
 	repo.URLs = make([]string, 0)
 	scanner := bufio.NewScanner(file)
 	// resize scanner's capacity if lines are longer than 64K.
 	for scanner.Scan() {
 		matches := mirrorlistRegex.FindStringSubmatch(scanner.Text())
-		if len(matches) > 0 {
+		if len(matches) > 0 { // skip invalid lines
 			url := matches[1]
 			if !strings.Contains(url, "$") {
 				repo.URLs = append(repo.URLs, url)
@@ -70,10 +75,9 @@ func updateRepoMirrorlist(repoName string, repo *Repo) error {
 				// this can be a regex error or otherwise a very peculiar url
 				log.Printf("warning: %v url in repo %v contains suspicious characters, skipping it", url, repoName)
 			}
-
 		}
-		// skip invalid lines
 	}
+
 	if len(repo.URLs) == 0 {
 		return fmt.Errorf("mirrorlist for repo %v is either empty or isn't a mirrorlist file", repoName)
 	}

--- a/mirrorlist.go
+++ b/mirrorlist.go
@@ -20,15 +20,15 @@ func updateMirrorlists() {
 
 func checkAndUpdateMirrorlistRepo(repoName string, repo *Repo) error {
 	if repo.Mirrorlist != "" {
-		repo.mutex.Lock()
-		defer repo.mutex.Unlock()
+		repo.Mutex.Lock()
+		defer repo.Mutex.Unlock()
 
-		if time.Since(repo.lastMirrorlistCheck) < 5*time.Second {
+		if time.Since(repo.LastMirrorlistCheck) < 5*time.Second {
 			// if there is an entry in the lastMirrorlistCheck and that entry has a distance lower than 5 seconds from now, don't update its mirrorlist
 			return nil
 		}
 
-		repo.lastMirrorlistCheck = time.Now()
+		repo.LastMirrorlistCheck = time.Now()
 		err := updateRepoMirrorlist(repoName, repo)
 		if err != nil {
 			return fmt.Errorf("error while updating %v repo mirrorlist: %v", repoName, err)
@@ -44,11 +44,11 @@ func updateRepoMirrorlist(repoName string, repo *Repo) error {
 	}
 
 	fileModTime := fileInfo.ModTime()
-	if fileModTime == repo.lastModificationTime {
+	if fileModTime == repo.LastModificationTime {
 		return nil
 	}
 
-	repo.lastModificationTime = fileModTime
+	repo.LastModificationTime = fileModTime
 
 	// open readonly, it won't change modification time
 	file, err := os.Open(repo.Mirrorlist)

--- a/mirrorlist.go
+++ b/mirrorlist.go
@@ -42,7 +42,13 @@ func updateRepoMirrorlist(repoName string, repo *Repo) error {
 	if err != nil {
 		return err
 	}
-	repo.lastModificationTime = fileInfo.ModTime()
+
+	fileModTime := fileInfo.ModTime()
+	if fileModTime == repo.lastModificationTime {
+		return nil
+	}
+
+	repo.lastModificationTime = fileModTime
 
 	// open readonly, it won't change modification time
 	file, err := os.Open(repo.Mirrorlist)

--- a/mirrorlist_test.go
+++ b/mirrorlist_test.go
@@ -85,7 +85,7 @@ repos:
 		PurgeFilesAfter: 2592000,
 		DownloadTimeout: 200,
 	}
-	if !cmp.Equal(*got, *want, cmpopts.IgnoreFields(Repo{}, "Mutex")) {
+	if !cmp.Equal(*got, *want, cmpopts.IgnoreFields(Repo{}, "mutex")) {
 		t.Errorf("got %v, want %v", *got, *want)
 	}
 
@@ -95,7 +95,7 @@ repos:
 	}
 	updateMirrorlists()
 	got = config
-	if !cmp.Equal(*got, *want, cmpopts.IgnoreFields(Repo{}, "Mutex")) {
+	if !cmp.Equal(*got, *want, cmpopts.IgnoreFields(Repo{}, "mutex")) {
 		t.Errorf("got %v, want %v", *got, *want)
 	}
 }

--- a/mirrorlist_test.go
+++ b/mirrorlist_test.go
@@ -55,12 +55,12 @@ repos:
 `))
 	config = got
 	updateMirrorlists()
-	gotModTime := config.Repos["archTest"].lastModificationTime
+	gotModTime := config.Repos["archTest"].LastModificationTime
 	expectedModTime := fileInfo.ModTime()
 	if gotModTime != expectedModTime {
 		t.Errorf("Got %v mod time, expected %v mod time", gotModTime, expectedModTime)
 	}
-	gotCheckTime := config.Repos["archTest"].lastMirrorlistCheck
+	gotCheckTime := config.Repos["archTest"].LastMirrorlistCheck
 	if time.Since(gotCheckTime) > 3*time.Second {
 		t.Errorf("Got %v check time, expected %v check time", gotCheckTime, time.Now())
 	}
@@ -78,12 +78,14 @@ repos:
 					`https://tooManyTests.com/archlinux/`,
 					`http://another.test.co.uk/archlinux/`,
 				},
+				LastModificationTime: gotModTime,
+				LastMirrorlistCheck:  gotCheckTime,
 			},
 		},
 		PurgeFilesAfter: 2592000,
 		DownloadTimeout: 200,
 	}
-	if !cmp.Equal(*got, *want, cmpopts.IgnoreUnexported(Repo{})) {
+	if !cmp.Equal(*got, *want, cmpopts.IgnoreFields(Repo{}, "Mutex")) {
 		t.Errorf("got %v, want %v", *got, *want)
 	}
 
@@ -93,7 +95,7 @@ repos:
 	}
 	updateMirrorlists()
 	got = config
-	if !cmp.Equal(*got, *want, cmpopts.IgnoreUnexported(Repo{})) {
+	if !cmp.Equal(*got, *want, cmpopts.IgnoreFields(Repo{}, "Mutex")) {
 		t.Errorf("got %v, want %v", *got, *want)
 	}
 }

--- a/mirrorlist_test.go
+++ b/mirrorlist_test.go
@@ -85,7 +85,7 @@ repos:
 		PurgeFilesAfter: 2592000,
 		DownloadTimeout: 200,
 	}
-	if !cmp.Equal(*got, *want, cmpopts.IgnoreFields(Repo{}, "mutex")) {
+	if !cmp.Equal(*got, *want, cmpopts.IgnoreFields(Repo{}, "timestampsMutex", "urlsMutex")) {
 		t.Errorf("got %v, want %v", *got, *want)
 	}
 
@@ -95,7 +95,7 @@ repos:
 	}
 	updateMirrorlists()
 	got = config
-	if !cmp.Equal(*got, *want, cmpopts.IgnoreFields(Repo{}, "mutex")) {
+	if !cmp.Equal(*got, *want, cmpopts.IgnoreFields(Repo{}, "timestampsMutex", "urlsMutex")) {
 		t.Errorf("got %v, want %v", *got, *want)
 	}
 }

--- a/pacoloco.go
+++ b/pacoloco.go
@@ -217,6 +217,8 @@ func prefetchRequest(url string, optionalCustomPath string) (err error) {
 			updateDBPrefetchedFile(repoName, fileName) // update info for prefetching
 		}
 	} else {
+		repo.urlsMutex.RLock()
+		defer repo.urlsMutex.RUnlock()
 		for _, url := range repo.URLs {
 			downloaded, err = downloadFile(url+path+"/"+fileName, filePath, ifLater)
 			if err == nil {

--- a/pacoloco.go
+++ b/pacoloco.go
@@ -310,6 +310,8 @@ func handleRequest(w http.ResponseWriter, req *http.Request) error {
 				updateDBRequestedDB(repoName, path, fileName)
 			}
 		} else {
+			repo.urlsMutex.RLock()
+			defer repo.urlsMutex.RUnlock()
 			for _, url := range repo.URLs {
 				served, err = downloadFileAndSend(url+path+"/"+fileName, filePath, ifLater, w)
 				if err == nil {

--- a/prefetch_integration_test.go
+++ b/prefetch_integration_test.go
@@ -67,7 +67,7 @@ func testPrefetchRequestNonExistingDb(t *testing.T) {
 
 func testPrefetchRequestExistingRepo(t *testing.T) {
 	// Requesting existing repo
-	config.Repos["repo1"] = Repo{}
+	config.Repos["repo1"] = &Repo{}
 	defer delete(config.Repos, "repo1")
 
 	if err := prefetchRequest("/repo/repo1/test.db", ""); err == nil {
@@ -82,7 +82,7 @@ func testPrefetchRequestExistingRepo(t *testing.T) {
 
 func testPrefetchRequestPackageFile(t *testing.T) {
 	// Requesting existing repo
-	config.Repos["repo3"] = Repo{
+	config.Repos["repo3"] = &Repo{
 		URL: mirrorURL + "/mirror3",
 	}
 	defer delete(config.Repos, "repo3")
@@ -141,7 +141,7 @@ func testPrefetchRequestPackageFile(t *testing.T) {
 }
 
 func testPrefetchFailover(t *testing.T) {
-	config.Repos["failover"] = Repo{
+	config.Repos["failover"] = &Repo{
 		URLs: []string{mirrorURL + "/no-mirror", mirrorURL + "/mirror-failover"},
 	}
 	defer delete(config.Repos, "failover")
@@ -175,7 +175,7 @@ func testPrefetchFailover(t *testing.T) {
 
 // prefetch an actual db and parses it
 func testPrefetchRealDB(t *testing.T) {
-	config.Repos["repo2"] = Repo{
+	config.Repos["repo2"] = &Repo{
 		URL: mirrorURL + "/mirror2",
 	}
 	defer delete(config.Repos, "repo2")
@@ -199,7 +199,7 @@ func testPrefetchRealDB(t *testing.T) {
 func testPrefetchRequestExistingRepoWithDb(t *testing.T) {
 	// Requesting existing repo
 
-	config.Repos["repo2"] = Repo{
+	config.Repos["repo2"] = &Repo{
 		URL: mirrorURL + "/mirror2",
 	}
 	defer delete(config.Repos, "repo2")
@@ -268,7 +268,7 @@ func testPrefetchRequestExistingRepoWithDb(t *testing.T) {
 func testIntegrationPrefetchAllPkgs(t *testing.T) {
 
 	// Setting up an existing repo
-	config.Repos["repo3"] = Repo{
+	config.Repos["repo3"] = &Repo{
 		URL: mirrorURL + "/mirror3",
 	}
 	defer delete(config.Repos, "repo3")


### PR DESCRIPTION
Hi, thanks for this great project. The concurrent writes issue from #44  seems to be crashing my pacoloco installation every couple of days. I think this change will fix the problem without adding too much extra complexity: the top-level `time.Time`-valued maps are removed and the times are stored on each `Repo` instead; and the write to `config.Repos` is removed by storing `*Repo` values and giving each one its own mutex.

Please let me know what else i can do to help. Thank you! :slightly_smiling_face: 