### PR TITLE
Download code refactoring (#7)(#30)(#58)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pacoloco - caching proxy server for pacman
 
-Pacoloco is a web server that acts if it was an Arch Linux pacman repository.
+Pacoloco is a web server that acts as if it was an Arch Linux pacman repository.
 Every time pacoloco server gets a request from user it downloads this file from
 real Arch Linux mirror and bypasses it to the user. Additionally pacoloco
 saves this file to local filesystem cache and serves it to the future users.
@@ -9,11 +9,11 @@ It also allows to prefetch updates of the most recently used packages.
 ## How does it help?
 
 Fast internet is still a luxury in many parts of the world. There are many places
-where access to internet is expensive and slow due to geographical and economical
+where internet access is expensive and slow due to geographical and economical
 reasons.
 
 Now think about a situation when multiple pacman users connected via fast local network.
-Each of these users needs to download the same set of files. _Pacoloco_ allows to minimize
+Each of these users needs to download the same set of files. _Pacoloco_ allows to reduce
 the Internet workload by caching pacman files content and serving it over
 fast local network.
 
@@ -33,28 +33,33 @@ Pacoloco can be used with docker.
 
 You can get a prebuilt image from GitHub's [container registry](https://github.com/anatol/pacoloco/pkgs/container/pacoloco) (see also sidebar).
 Currently only amd64 is supported.
+
 ```sh
 docker pull ghcr.io/anatol/pacoloco
 ```
+
 Available tags are: `latest` = git master and any git tags.
 
-
 You can also build it yourself:
+
 ```sh
 $ git clone https://github.com/anatol/pacoloco && cd pacoloco
 $ docker build -t ghcr.io/anatol/pacoloco .
 ```
 
 Run it like this:
+
 ```sh
 $ docker run -p 9129:9129 \
     -v /path/to/config/pacoloco.yaml:/etc/pacoloco.yaml \
     -v /path/to/cache:/var/cache/pacoloco \
     ghcr.io/anatol/pacoloco
 ```
+
 You need to provide paths or volumes to store application data.
 
 Alternatively, you can use docker-compose:
+
 ```yaml
 ---
 version: "3.8"
@@ -101,27 +106,55 @@ repos:
   archlinux-reflector:
     mirrorlist: /etc/pacman.d/reflector_mirrorlist # Be careful! Check that pacoloco URL is NOT included in that file!
 http_proxy: http://foo.company.com:8989 # Enable this only if you have pacoloco running behind a proxy
-user_agent: Pacoloco/1.2
+user_agent: Pacoloco/1.2.1
 prefetch: # optional section, add it if you want to enable prefetching
   cron: 0 0 3 * * * * # standard cron expression (https://en.wikipedia.org/wiki/Cron#CRON_expression) to define how frequently prefetch, see https://github.com/gorhill/cronexpr#implementation for documentation.
-  ttl_unaccessed_in_days: 30  # defaults to 30, set it to a higher value than the number of consecutive days you don't update your systems
+  ttl_unaccessed_in_days: 30 # defaults to 30, set it to a higher value than the number of consecutive days you don't update your systems
   # It deletes and stop prefetch packages(and db links) when not downloaded after ttl_unaccessed_in_days days that it had been updated.
   ttl_unupdated_in_days: 300 # defaults to 300, it deletes and stop prefetch packages which hadn't been either updated upstream or requested for ttl_unupdated_in_days.
 ```
 
-* `cache_dir` is the cache directory, this location needs to read/writable by the server process.
-* `purge_files_after` specifies inactivity duration (in seconds) after which the file should be removed from the cache. This functionality uses unix "AccessTime" field to find out inactive files. Default value is `0` that means never run the purging.
-* `port` is the server port.
-* `download_timeout` is a timeout (in seconds) for internet->cache downloads. If a remote server gets slow and file download takes longer than this will be terminated. Default value is `0` that means no timeout.
-* `repos` is a list of repositories to mirror. Each repo needs `name` and url of its Arch mirrors. Note that url can be specified either with `url` or `urls` properties, one and only one can be used for each repo configuration.
-* `http_proxy` is only to be used if you have pacoloco running behind a proxy
-* `user_agent` user agent used to fetch the files from repositories. Default value is `Pacoloco/1.2`.
-* The `prefetch` section allows to enable packages prefetching. Comment it out to disable it.
-* To test out if the cron value does what you'd expect to do, check cronexpr [implementation](https://github.com/gorhill/cronexpr#implementation) or [test it](https://play.golang.org/p/IK2hrIV7tUk)
-* For what regards `mirrorlist`, be sure that pacoloco itself is NOT included in the chosen `mirrorlist` file. It can be integrated with reflector too, either by changing reflector's output path or by including pacoloco directly for standard repos in `/etc/pacman.conf` (e.g. adding a `Server=...` entry or a custom mirrorlist file which includes only pacoloco URL).
+- `cache_dir` is the cache directory, this location needs to read/writable by the server process.
+- `purge_files_after` specifies inactivity duration (in seconds) after which the file should be removed from the cache. This functionality uses unix "AccessTime" field to find out inactive files. Default value is `0` that means never run the purging.
+- `port` is the server port.
+- `download_timeout` is a timeout (in seconds) for internet->cache downloads. If a remote server gets slow and file download takes longer than this will be terminated. Default value is `0` that means no timeout.
+- `repos` is a list of repositories to mirror. Each repo needs `name` and url of its Arch mirrors. Note that url can be specified either with `url` or `urls` properties, one and only one can be used for each repo configuration.
+- `http_proxy` is only to be used if you have pacoloco running behind a proxy.
+- `user_agent` user agent used to fetch the files from repositories. Default value is `Pacoloco/1.2.1`.
+- The `prefetch` section allows to enable packages prefetching. Comment it out to disable it.
+- To test out if the cron value does what you'd expect to do, check cronexpr [implementation](https://github.com/gorhill/cronexpr#implementation) or [test it](https://play.golang.org/p/IK2hrIV7tUk)
+- For what regards `mirrorlist`, be sure that pacoloco itself is NOT included in the chosen `mirrorlist` file. It can be integrated with reflector too, either by changing reflector's output path or by including pacoloco directly for standard repos in `/etc/pacman.conf` (e.g. adding a `Server=...` entry or a custom mirrorlist file which includes only pacoloco URL).
 
 With the example configured above `http://YOURSERVER:9129/repo/archlinux` looks exactly like an Arch pacman mirror.
 For example a request to `http://YOURSERVER:9129/repo/archlinux/core/os/x86_64/openssh-8.2p1-3-x86_64.pkg.tar.zst` will be served with file content from `http://mirror.lty.me/archlinux/core/os/x86_64/openssh-8.2p1-3-x86_64.pkg.tar.zst`
+
+### Using mirrorlist
+
+Once the pacoloco server is up and running it is time to configure the user host. Modify user's `/etc/pacman.conf` with
+
+```conf
+[core]
+Server = http://yourpacoloco:9129/repo/archlinux/$repo/os/$arch
+Include = /etc/pacman.d/mirrorlist
+
+[extra]
+Server = http://yourpacoloco:9129/repo/archlinux/$repo/os/$arch
+Include = /etc/pacman.d/mirrorlist
+
+[community]
+Server = http://yourpacoloco:9129/repo/archlinux/$repo/os/$arch
+Include = /etc/pacman.d/mirrorlist
+
+[quarry]
+Server = http://yourpacoloco:9129/repo/quarry
+
+[sublime-text]
+Server = http://yourpacoloco:9129/repo/sublime
+```
+
+That's it. Since now pacman requests will be proxied through our pacoloco server.
+
+### Using urls
 
 Once the pacoloco server is up and running it is time to configure the user host. Modify user's `/etc/pacman.conf` with
 
@@ -152,7 +185,7 @@ That's it. Since now pacman requests will be proxied through our pacoloco server
 
 ## Handling multiple architectures
 
-*pacoloco* does not care about the architecture of your repo as it acts as a mere proxy.
+_pacoloco_ does not care about the architecture of your repo as it acts as a mere proxy.
 
 Thus it can handle multiple different arches transparently. One way to do it is to add multiple
 repositories with names `foobar_$arch` e.g.:
@@ -169,7 +202,7 @@ repos:
     url: http://mirror.clarkson.edu/archlinux32
 ```
 
-Then modify user's `/etc/pacman.d/mirrorlist` and add
+Then, if modify user's `/etc/pacman.d/mirrorlist` and add
 
 For x86_64:
 

--- a/config.go
+++ b/config.go
@@ -33,15 +33,17 @@ type RefreshPeriod struct {
 }
 
 type Config struct {
-	CacheDir        string           `yaml:"cache_dir"`
-	Port            int              `yaml:"port"`
-	Repos           map[string]*Repo `yaml:"repos,omitempty"`
-	PurgeFilesAfter int              `yaml:"purge_files_after"`
-	DownloadTimeout int              `yaml:"download_timeout"`
-	Prefetch        *RefreshPeriod   `yaml:"prefetch"`
-	HttpProxy       string           `yaml:"http_proxy"`
-	UserAgent       string           `yaml:"user_agent"`
-	LogTimestamp    bool             `yaml:"set_timestamp_to_logs"`
+	CacheDir                string           `yaml:"cache_dir"`
+	Port                    int              `yaml:"port"`
+	Repos                   map[string]*Repo `yaml:"repos,omitempty"`
+	PurgeFilesAfter         int              `yaml:"purge_files_after"`
+	DownloadTimeout         int              `yaml:"download_timeout"`
+	SkipHeadCheck           bool             `yaml:"skip_file_availability_check"`
+	FileAvailabilityTimeout int              `yaml:"file_availability_timeout_ms"`
+	Prefetch                *RefreshPeriod   `yaml:"prefetch"`
+	HttpProxy               string           `yaml:"http_proxy"`
+	UserAgent               string           `yaml:"user_agent"`
+	LogTimestamp            bool             `yaml:"set_timestamp_to_logs"`
 }
 
 var config *Config

--- a/config_test.go
+++ b/config_test.go
@@ -38,6 +38,7 @@ prefetch:
   cron: 0 0 3 * * * *
   ttl_unaccessed_in_days: 5
 download_timeout: 200
+skip_file_availability_check: y
 port: 9139
 repos:
   archlinux:
@@ -54,6 +55,7 @@ repos:
 		},
 		PurgeFilesAfter: 2592000,
 		DownloadTimeout: 200,
+		SkipHeadCheck:   true,
 		Prefetch:        &RefreshPeriod{Cron: "0 0 3 * * * *", TTLUnaccessed: 5, TTLUnupdated: 200},
 	}
 	if !cmp.Equal(*got, *want, cmpopts.IgnoreFields(Config{}, "Prefetch"), cmpopts.IgnoreUnexported(Repo{})) {

--- a/pacoloco.yaml.sample
+++ b/pacoloco.yaml.sample
@@ -1,7 +1,9 @@
 # cache_dir: /var/cache/pacoloco
 # port: 9129
-download_timeout: 3600 # downloads will timeout if not completed after 3600 sec, 0 to disable timeout
+download_timeout: 3600 # timeout in seconds. Individual downloads will timeout if not completed after 1h, 0 to disable timeout
 purge_files_after: 2592000 # purge file after 30 days
+# skip_file_availability_check: y # Uncomment to disable HEAD requests before downloads. Skipping those should increase requests timeout
+# file_availability_timeout_ms: 2000 # Set the HEAD request timeout. Default is 2000ms
 # set_timestamp_to_logs: true # uncomment to add timestamp, useful if pacoloco is being ran through docker
 
 repos:
@@ -10,15 +12,16 @@ repos:
       - http://mirror.lty.me/archlinux
       - http://mirrors.kernel.org/archlinux
   archlinux-reflector:
-    mirrorlist: /etc/pacman.d/mirrorlist # Be careful! Check that pacoloco URL is NOT included in that file!
+    mirrorlist: /etc/pacman.d/mirrorlist # Specify a mirrorlist file from which fetch mirrors url.
+    # Be careful! Check that pacoloco URL is NOT included in that file!
   quarry:
     url: http://pkgbuild.com/~anatolik/quarry/x86_64
   sublime:
     url: https://download.sublimetext.com/arch/stable/x86_64
 prefetch: # optional section, add it if you want to enable prefetching
   cron: 0 0 3 * * * * # standard cron expression (https://en.wikipedia.org/wiki/Cron#CRON_expression) to define how frequently prefetch, see https://github.com/gorhill/cronexpr#implementation for documentation.
-  ttl_unaccessed_in_days: 30  # defaults to 30, set it to a higher value than the number of consecutive days you don't update your systems
+  ttl_unaccessed_in_days: 30 # defaults to 30, set it to a higher value than the number of consecutive days you don't update your systems
   # It deletes and stop prefetch packages(and db links) when not downloaded after ttl_unaccessed_in_days days that it had been updated.
   ttl_unupdated_in_days: 300 # defaults to 300, it deletes and stop prefetch packages which hadn't been either updated upstream or requested for ttl_unupdated_in_days.
 # http_proxy: http://proxy.company.com:8888 # Enable this if you have pacoloco running behind a proxy
-# user_agent: Pacoloco/1.2
+# user_agent: Pacoloco/1.2.1

--- a/pacoloco_test.go
+++ b/pacoloco_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -19,12 +20,12 @@ func TestMain(m *testing.M) {
 }
 
 func TestPathMatcher(t *testing.T) {
-	pathCheck := func(url string, repoName string, path string, fileName string) {
-		matches := pathRegex.FindStringSubmatch(url)
+	pathCheck := func(url string, repoName string, urlPath string, fileName string) {
+		matches := pathRegex.FindStringSubmatch(path.Clean(url))
 		if matches == nil {
 			t.Errorf("url '%v' does not match regexp", url)
 		}
-		expected := []string{url, repoName, path, fileName}
+		expected := []string{url, repoName, urlPath, fileName}
 
 		if !cmp.Equal(matches, expected) {
 			t.Errorf("expected '%v' but regexp submatches '%v'", expected, matches)
@@ -32,7 +33,7 @@ func TestPathMatcher(t *testing.T) {
 	}
 
 	pathFails := func(url string) {
-		matches := pathRegex.FindStringSubmatch(url)
+		matches := pathRegex.FindStringSubmatch(path.Clean(url))
 		if matches != nil {
 			t.Errorf("url '%v' expected to fail matching", url)
 		}
@@ -43,6 +44,8 @@ func TestPathMatcher(t *testing.T) {
 	pathFails("repo/foo/webkit2gtk-2.26.4-1-x86_64.pkg.tar.zst")
 	pathFails("/repo/webkit2gtk-2.26.4-1-x86_64.pkg.tar.zst")
 	pathFails("/webkit2gtk/repo/foo/-2.26.4-1-x86_64.pkg.tar.zst")
+	pathFails("/repo/foo/../webkit2gtk-2.26.4-1-x86_64.pkg.tar.zst")
+	pathFails("/repo/../whatever/webkit2gtk-2.26.4-1-x86_64.pkg.tar.zst")
 
 	pathCheck("/repo/foo/webkit2gtk-2.26.4-1-x86_64.pkg.tar.zst", "foo", "", "webkit2gtk-2.26.4-1-x86_64.pkg.tar.zst")
 	pathCheck("/repo/foo/bar/bazzz/eeee/webkit2x86_64.pkg.tar.zst", "foo", "/bar/bazzz/eeee", "webkit2x86_64.pkg.tar.zst")

--- a/prefetch.go
+++ b/prefetch.go
@@ -167,7 +167,7 @@ func purgePkgIfExists(pkgToDel *Package) {
 		basePathsToDelete := pkgToDel.getAllPaths()
 		for _, p := range basePathsToDelete {
 			pathToDelete := path.Join(config.CacheDir, p)
-			if _, err := os.Stat(pathToDelete); !os.IsNotExist(err) {
+			if _, err := os.Stat(pathToDelete); err == nil {
 				// if it exists, delete it
 				if err := os.Remove(pathToDelete); err != nil {
 					log.Printf("Error while trying to remove unused package %v : %v", pathToDelete, err)

--- a/prefetch_db.go
+++ b/prefetch_db.go
@@ -224,7 +224,7 @@ func updateDBRequestedDB(repoName string, path_ string, filename string) (Mirror
 		log.Fatalf("prefetchDB is uninitialized")
 	}
 	urlDB := path.Join("/repo/", repoName, path_, filename)
-	matches := pathRegex.FindStringSubmatch(urlDB)
+	matches := pathRegex.FindStringSubmatch(path.Clean(urlDB))
 	if len(matches) == 0 {
 		return MirrorDB{}, fmt.Errorf("url '%v' is invalid, cannot save it for prefetching", urlDB)
 	}

--- a/prefetch_db_test.go
+++ b/prefetch_db_test.go
@@ -201,7 +201,7 @@ func TestDropUnusedDBFiles(t *testing.T) {
 	}
 	var mirr MirrorDB
 	prefetchDB.Model(&MirrorDB{}).Where("mirror_dbs.url = ? and mirror_dbs.repo_name = ?", "/repo/example/url/test.db", "example").First(&mirr)
-	matches := pathRegex.FindStringSubmatch(mirr.URL)
+	matches := pathRegex.FindStringSubmatch(path.Clean(mirr.URL))
 	if len(matches) == 0 {
 		t.Errorf("It should be a proper pacoloco path url")
 	}

--- a/prefetch_integration_test.go
+++ b/prefetch_integration_test.go
@@ -67,8 +67,8 @@ func testPrefetchRequestNonExistingDb(t *testing.T) {
 func testPrefetchRequestExistingRepo(t *testing.T) {
 	// Requesting existing repo
 	config.Repos["repo1"] = &Repo{}
+	config.Repos["repo1"].URL = "example.com/foo"
 	defer delete(config.Repos, "repo1")
-
 	if err := prefetchRequest("/repo/repo1/test.db", ""); err == nil {
 		t.Error("Error expected")
 	}
@@ -77,22 +77,33 @@ func testPrefetchRequestExistingRepo(t *testing.T) {
 	if _, err := os.Stat(path.Join(testPacolocoDir, "pkgs", "repo1", "test.db")); !os.IsNotExist(err) {
 		t.Error("repo1/test.db should not be cached")
 	}
+	config.Repos["repo2"] = &Repo{}
+	config.Repos["repo2"].URLs = []string{"example.com/foo", "example.com/bar"}
+	if err := prefetchRequest("/repo/repo2/test2.db", ""); err == nil {
+		t.Error("Error expected")
+	}
+
+	// check that db is not cached
+	if _, err := os.Stat(path.Join(testPacolocoDir, "pkgs", "repo2", "test2.db")); !os.IsNotExist(err) {
+		t.Error("repo1/test.db should not be cached")
+	}
+	defer delete(config.Repos, "repo2")
 }
 
 func testPrefetchRequestPackageFile(t *testing.T) {
 	// Requesting existing repo
-	repo3 := &Repo{
-		URL: mirrorURL + "/mirror3",
+	repo5 := &Repo{
+		URL: mirrorURL + "/mirror5",
 	}
-	config.Repos["repo3"] = repo3
-	defer delete(config.Repos, "repo3")
+	config.Repos["repo5"] = repo5
+	defer delete(config.Repos, "repo5")
 
-	if err := os.Mkdir(path.Join(mirrorDir, "mirror3"), os.ModePerm); err != nil {
+	if err := os.Mkdir(path.Join(mirrorDir, "mirror5"), os.ModePerm); err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(path.Join(mirrorDir, "mirror3"))
+	defer os.RemoveAll(path.Join(mirrorDir, "mirror5"))
 
-	pkgAtMirror := path.Join(mirrorDir, "mirror3", "test-1-1-any.pkg.tar.zst")
+	pkgAtMirror := path.Join(mirrorDir, "mirror5", "test-1-1-any.pkg.tar.zst")
 	pkgFileContent := "a package"
 	if err := os.WriteFile(pkgAtMirror, []byte(pkgFileContent), os.ModePerm); err != nil {
 		t.Fatal(err)
@@ -101,14 +112,14 @@ func testPrefetchRequestPackageFile(t *testing.T) {
 	pkgModTime := time.Now().Add(-time.Hour)
 	os.Chtimes(pkgAtMirror, pkgModTime, pkgModTime)
 
-	err := prefetchRequest("/repo/repo3/test-1-1-any.pkg.tar.zst", "")
+	err := prefetchRequest("/repo/repo5/test-1-1-any.pkg.tar.zst", "")
 
-	defer os.RemoveAll(path.Join(testPacolocoDir, "pkgs", "repo3")) // remove cached content
+	defer os.RemoveAll(path.Join(testPacolocoDir, "pkgs", "repo5")) // remove cached content
 
 	if err != nil {
 		t.Errorf("Expected success, got %v", err)
 	}
-	content, err := os.ReadFile(path.Join(testPacolocoDir, "pkgs", "repo3", "test-1-1-any.pkg.tar.zst"))
+	content, err := os.ReadFile(path.Join(testPacolocoDir, "pkgs", "repo5", "test-1-1-any.pkg.tar.zst"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -125,18 +136,18 @@ func testPrefetchRequestPackageFile(t *testing.T) {
 	newDbModTime := time.Now()
 	os.Chtimes(pkgAtMirror, newDbModTime, newDbModTime)
 
-	err = prefetchRequest("/repo/repo3/test-1-1-any.pkg.tar.zst", "")
+	err = prefetchRequest("/repo/repo5/test-1-1-any.pkg.tar.zst", "") // the same file still exists, there is no need to download it again
 
-	if err != nil {
-		t.Errorf("Expected success, got %v", err)
+	if err == nil {
+		t.Errorf("Expected failure, got %v", err)
 	}
 
-	content, err = os.ReadFile(path.Join(testPacolocoDir, "pkgs", "repo3", "test-1-1-any.pkg.tar.zst"))
+	content, err = os.ReadFile(path.Join(testPacolocoDir, "pkgs", "repo5", "test-1-1-any.pkg.tar.zst"))
 	if err != nil {
 		log.Fatal(err)
 	}
-	if string(content) != newContent {
-		t.Errorf("Pacoloco cached incorrect db content: %v", string(content))
+	if string(content) != pkgFileContent {
+		t.Errorf("Pacoloco cached incorrect db content: %v, expected %v. The new content had been set to %v.", string(content), string(pkgFileContent), string(newContent))
 	}
 }
 
@@ -247,7 +258,8 @@ func testPrefetchRequestExistingRepoWithDb(t *testing.T) {
 		t.Errorf("Got incorrect db content: %v", string(content))
 	}
 
-	// Now let's modify the db content, pacoloco should refetch it
+	// The prefetching mechanism should NOT refetch the file, as it is its job to provide cached content
+	oldContent := dbFileContent
 	dbFileContent = "This is a new content"
 	if err := os.WriteFile(dbAtMirror, []byte(dbFileContent), os.ModePerm); err != nil {
 		t.Fatal(err)
@@ -264,43 +276,43 @@ func testPrefetchRequestExistingRepoWithDb(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(content) != dbFileContent {
-		t.Errorf("Pacoloco cached incorrect db content: %v\n instead of %v", string(content), dbFileContent)
+	if string(content) != oldContent {
+		t.Errorf("Pacoloco cached unexpected db content: %v\n instead of %v. The new content was %v", string(content), string(oldContent), string(dbFileContent))
 	}
 }
 
 // The most complete integration test for prefetching
 func testIntegrationPrefetchAllPkgs(t *testing.T) {
-	// Setting up an existing repo
-	repo3 := &Repo{
-		URL: mirrorURL + "/mirror3",
+	// Setting up an existing repository
+	testSetupHelper(t)
+	repo6 := &Repo{}
+	repo6.URL = mirrorURL + "/mirror6"
+	config.Repos["repo6"] = repo6
+	defer delete(config.Repos, "repo6")
+	// create a mirror dir, so that on mirror6 you can fetch the db
+	if err := os.Mkdir(path.Join(mirrorDir, "mirror6"), os.ModePerm); err != nil {
+		t.Errorf("Can't create mirror6 directory, %v", err)
 	}
-	config.Repos["repo3"] = repo3
-	defer delete(config.Repos, "repo3")
-
-	if err := os.Mkdir(path.Join(mirrorDir, "mirror3"), os.ModePerm); err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(path.Join(mirrorDir, "mirror3"))
-	// create a valid db file on the mirror
-	dbAtMirror := path.Join(mirrorDir, "mirror3", "test.db")
+	defer os.RemoveAll(path.Join(mirrorDir, "mirror6"))
+	// create a valid db file with acl entry for version 2.3.1-1 on the mirror, to be served on mirror6 path
+	dbAtMirror := path.Join(mirrorDir, "mirror6", "test.db")
 	createDbTarball(dbAtMirror, getTestTarDB())
-	// fake a request to the db
-	if _, err := updateDBRequestedDB("repo3", "", "/test.db"); err != nil {
+	// fake a request to the db, so that there is a record of a requested test.db file
+	if _, err := updateDBRequestedDB("repo6", "", "/test.db"); err != nil {
 		t.Errorf("Should not generate errors, but got %v", err)
 	}
-	// now add a fake older version of a package which is in the db
-	updateDBRequestedFile("repo3", "acl-2.0-0-x86_64.pkg.tar.zst")
-	// now i add a bit newer one, to ensure that the db gets updated accordingly
-	updateDBRequestedFile("repo3", "acl-2.1-0-x86_64.pkg.tar.zst")
-	// create the directories in the cache
-	if err := os.Mkdir(path.Join(config.CacheDir, "pkgs", "repo3"), os.ModePerm); err != nil {
+	// assume an older version of acl package had been successfully requested (this should create a first entry in the db)
+	updateDBRequestedFile("repo6", "acl-2.0-0-x86_64.pkg.tar.zst")
+	// assume that a newer version had been successfully requested (this should update the entry in the db)
+	updateDBRequestedFile("repo6", "acl-2.1-0-x86_64.pkg.tar.zst")
+	// create the directories in the pacoloco cache
+	if err := os.MkdirAll(path.Join(config.CacheDir, "pkgs", "repo6"), os.ModePerm); err != nil {
 		t.Fatal(err)
 	}
 
 	defer os.RemoveAll(path.Join(config.CacheDir, "pkgs"))
-	// create this file in the cache
-	pkgAtCache := path.Join(config.CacheDir, "pkgs", "repo3", "acl-2.1-0-x86_64.pkg.tar.zst")
+	// create the "latest" package file in the cache, to fake a previous successful fetching of the package
+	pkgAtCache := path.Join(config.CacheDir, "pkgs", "repo6", "acl-2.1-0-x86_64.pkg.tar.zst")
 	pkgAtCacheContent := "cached old content"
 
 	if err := os.WriteFile(pkgAtCache, []byte(pkgAtCacheContent), os.ModePerm); err != nil {
@@ -310,8 +322,8 @@ func testIntegrationPrefetchAllPkgs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// create a package file which should be prefetched with signature (the signature is invalid but I'm not checking it) on the mirror
-	pkgAtMirror := path.Join(mirrorDir, "mirror3", "acl-2.3.1-1-x86_64.pkg.tar.zst")
+	// create an updated package file which should be prefetched with its signature (the signature is invalid but I'm not checking it) on the mirror
+	pkgAtMirror := path.Join(mirrorDir, "mirror6", "acl-2.3.1-1-x86_64.pkg.tar.zst")
 	pkgContent := "TEST content for the file to be prefetched"
 	if err := os.WriteFile(pkgAtMirror, []byte(pkgContent), os.ModePerm); err != nil {
 		t.Fatal(err)
@@ -319,8 +331,8 @@ func testIntegrationPrefetchAllPkgs(t *testing.T) {
 	if err := os.WriteFile(pkgAtMirror+".sig", []byte(pkgContent), os.ModePerm); err != nil {
 		t.Fatal(err)
 	}
-	// create an updated package file with a wrong extension which should NOT be prefetched with signature (the signature is invalid but I'm not checking it) on the mirror
-	wrongPkgAtMirror := path.Join(mirrorDir, "mirror3", "acl-2.3.1-1-x86_64.pkg.tar")
+	// create an updated package file with a wrong extension which should NOT be prefetched (with signature too) on the mirror
+	wrongPkgAtMirror := path.Join(mirrorDir, "mirror6", "acl-2.3.1-1-x86_64.pkg.tar")
 	wrongPkgContent := "TEST content for the file which should NOT be prefetched"
 	if err := os.WriteFile(wrongPkgAtMirror, []byte(wrongPkgContent), os.ModePerm); err != nil {
 		t.Fatal(err)
@@ -336,17 +348,17 @@ func testIntegrationPrefetchAllPkgs(t *testing.T) {
 		log.Fatal(err)
 	}
 	if exists {
-		t.Errorf("The file %v should not exist", pkgAtCache)
+		t.Errorf("The file %v should not exist because a newer version should have been prefetched", pkgAtCache)
 	}
 	exists, err = fileExists(pkgAtCache + ".sig")
 	if err != nil {
 		log.Fatal(err)
 	}
 	if exists {
-		t.Errorf("The file %v should not exist", pkgAtCache+".sig")
+		t.Errorf("The file %v should not exist because a newer version should have been prefetched", pkgAtCache+".sig")
 	}
 	// new packages should appear
-	pkgAtCache = path.Join(config.CacheDir, "pkgs", "repo3", "acl-2.3.1-1-x86_64.pkg.tar.zst")
+	pkgAtCache = path.Join(config.CacheDir, "pkgs", "repo6", "acl-2.3.1-1-x86_64.pkg.tar.zst")
 	exists, err = fileExists(pkgAtCache)
 	if err != nil {
 		log.Fatal(err)
@@ -379,7 +391,7 @@ func testIntegrationPrefetchAllPkgs(t *testing.T) {
 		t.Errorf("Got %v ,want %v", got, want)
 	}
 	// new packages with the wrong extension should not appear
-	pkgAtCache = path.Join(config.CacheDir, "pkgs", "repo3", "acl-2.3.1-1-x86_64.pkg.tar")
+	pkgAtCache = path.Join(config.CacheDir, "pkgs", "repo6", "acl-2.3.1-1-x86_64.pkg.tar")
 	exists, err = fileExists(pkgAtCache)
 	if err != nil {
 		log.Fatal(err)

--- a/repo_db_mirror.go
+++ b/repo_db_mirror.go
@@ -146,7 +146,7 @@ func downloadAndParseDb(mirror MirrorDB) error {
 			return err
 		}
 	}
-	matches := pathRegex.FindStringSubmatch(mirror.URL)
+	matches := pathRegex.FindStringSubmatch(path.Clean(mirror.URL))
 	if len(matches) == 0 {
 		return fmt.Errorf("url '%v' is invalid, does not match path regex", mirror.URL)
 	}


### PR DESCRIPTION
Support for partially downloaded files with redirects if unavailable, ranges are now supported  (#7) 
No more file downloaded at the same time with unexpected behaviour (#30)
Should reduce download latency with granular error handling and HEAD requests before downloads (#58)
Updated readme formatting


I have rewritten some code parts in handleRequest and fixed some race conditions which could happen because of how mutexes were being used. Now if pacoloco shouldn't handle the request (because the file is partial and it is being downloaded), it replies with a 302 to the upstream mirror, so that it won't break the download to other clients (and then it would allow partial downloads for cached packages).
Also, this PR should reduce timeout waiting by trying a HEAD request before trying to download a file which is not available upstream.
It includes also some formatting fixes in the readme, as well as with some improved examples.