### PR TITLE
Clarify use of http_proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ repos:
     url: https://download.sublimetext.com/arch/stable/x86_64
   archlinux-reflector:
     mirrorlist: /etc/pacman.d/reflector_mirrorlist # Be careful! Check that pacoloco URL is NOT included in that file!
-http_proxy: http://foo.company.com:8989
+http_proxy: http://foo.company.com:8989 # Enable this only if you have pacoloco running behind a proxy
 user_agent: Pacoloco/1.2
 prefetch: # optional section, add it if you want to enable prefetching
-  cron: 0 0 3 * * * * # standard cron expression (https://en.wikipedia.org/wiki/Cron#CRON_expression) to define how frequently prefetch, see https://github.com/gorhill/cronexpr#implementation for documentation.
+  cron: 0 3 * * * # standard cron expression (https://en.wikipedia.org/wiki/Cron#CRON_expression) to define how frequently prefetch, see https://github.com/gorhill/cronexpr#implementation for documentation.
   ttl_unaccessed_in_days: 30  # defaults to 30, set it to a higher value than the number of consecutive days you don't update your systems
   # It deletes and stop prefetch packages(and db links) when not downloaded after ttl_unaccessed_in_days days that it had been updated.
   ttl_unupdated_in_days: 300 # defaults to 300, it deletes and stop prefetch packages which hadn't been either updated upstream or requested for ttl_unupdated_in_days.
@@ -114,7 +114,7 @@ prefetch: # optional section, add it if you want to enable prefetching
 * `port` is the server port.
 * `download_timeout` is a timeout (in seconds) for internet->cache downloads. If a remote server gets slow and file download takes longer than this will be terminated. Default value is `0` that means no timeout.
 * `repos` is a list of repositories to mirror. Each repo needs `name` and url of its Arch mirrors. Note that url can be specified either with `url` or `urls` properties, one and only one can be used for each repo configuration.
-* `http_proxy` proxy configuration that is used to fetch files from repositories.
+* `http_proxy` is only to be used if you have pacoloco running behind a proxy
 * `user_agent` user agent used to fetch the files from repositories. Default value is `Pacoloco/1.2`.
 * The `prefetch` section allows to enable packages prefetching. Comment it out to disable it.
 * To test out if the cron value does what you'd expect to do, check cronexpr [implementation](https://github.com/gorhill/cronexpr#implementation) or [test it](https://play.golang.org/p/IK2hrIV7tUk)

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ repos:
 http_proxy: http://foo.company.com:8989 # Enable this only if you have pacoloco running behind a proxy
 user_agent: Pacoloco/1.2
 prefetch: # optional section, add it if you want to enable prefetching
-  cron: 0 3 * * * # standard cron expression (https://en.wikipedia.org/wiki/Cron#CRON_expression) to define how frequently prefetch, see https://github.com/gorhill/cronexpr#implementation for documentation.
+  cron: 0 0 3 * * * * # standard cron expression (https://en.wikipedia.org/wiki/Cron#CRON_expression) to define how frequently prefetch, see https://github.com/gorhill/cronexpr#implementation for documentation.
   ttl_unaccessed_in_days: 30  # defaults to 30, set it to a higher value than the number of consecutive days you don't update your systems
   # It deletes and stop prefetch packages(and db links) when not downloaded after ttl_unaccessed_in_days days that it had been updated.
   ttl_unupdated_in_days: 300 # defaults to 300, it deletes and stop prefetch packages which hadn't been either updated upstream or requested for ttl_unupdated_in_days.

--- a/pacoloco.yaml.sample
+++ b/pacoloco.yaml.sample
@@ -16,7 +16,7 @@ repos:
   sublime:
     url: https://download.sublimetext.com/arch/stable/x86_64
 prefetch: # optional section, add it if you want to enable prefetching
-  cron: 0 3 * * * # standard cron expression (https://en.wikipedia.org/wiki/Cron#CRON_expression) to define how frequently prefetch, see https://github.com/gorhill/cronexpr#implementation for documentation.
+  cron: 0 0 3 * * * * # standard cron expression (https://en.wikipedia.org/wiki/Cron#CRON_expression) to define how frequently prefetch, see https://github.com/gorhill/cronexpr#implementation for documentation.
   ttl_unaccessed_in_days: 30  # defaults to 30, set it to a higher value than the number of consecutive days you don't update your systems
   # It deletes and stop prefetch packages(and db links) when not downloaded after ttl_unaccessed_in_days days that it had been updated.
   ttl_unupdated_in_days: 300 # defaults to 300, it deletes and stop prefetch packages which hadn't been either updated upstream or requested for ttl_unupdated_in_days.

--- a/pacoloco.yaml.sample
+++ b/pacoloco.yaml.sample
@@ -16,9 +16,9 @@ repos:
   sublime:
     url: https://download.sublimetext.com/arch/stable/x86_64
 prefetch: # optional section, add it if you want to enable prefetching
-  cron: 0 0 3 * * * * # standard cron expression (https://en.wikipedia.org/wiki/Cron#CRON_expression) to define how frequently prefetch, see https://github.com/gorhill/cronexpr#implementation for documentation.
+  cron: 0 3 * * * # standard cron expression (https://en.wikipedia.org/wiki/Cron#CRON_expression) to define how frequently prefetch, see https://github.com/gorhill/cronexpr#implementation for documentation.
   ttl_unaccessed_in_days: 30  # defaults to 30, set it to a higher value than the number of consecutive days you don't update your systems
   # It deletes and stop prefetch packages(and db links) when not downloaded after ttl_unaccessed_in_days days that it had been updated.
   ttl_unupdated_in_days: 300 # defaults to 300, it deletes and stop prefetch packages which hadn't been either updated upstream or requested for ttl_unupdated_in_days.
-# http_proxy: http://proxy.company.com:8888
+# http_proxy: http://proxy.company.com:8888 # Enable this if you have pacoloco running behind a proxy
 # user_agent: Pacoloco/1.2


### PR DESCRIPTION
The http_proxy config was not obvious to me (Cf. [Issue 75](https://github.com/anatol/pacoloco/issues/75)), so I created this PR in the hope that it would clarify the use of the http_proxy config.

~~This PR also changes the cron configuration from having 7 items (currently: "cron: 0 0 3 * * * *") to 5 (cron: 0 3 * * *), as I think cron can only take 5 arguments.~~ (reverted this, because the golang library in use here requires 7 expressions)