### PR TITLE
Add zstd prefetching support (#48)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,5 +14,6 @@ require (
 require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
+	github.com/klauspost/compress v1.16.4 // indirect
 	github.com/mattn/go-sqlite3 v1.14.16 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkr
 github.com/jinzhu/now v1.1.4/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+github.com/klauspost/compress v1.16.4 h1:91KN02FnsOYhuunwU4ssRe8lc2JosWmizWa91B5v1PU=
+github.com/klauspost/compress v1.16.4/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/mattn/go-sqlite3 v1.14.15/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/mattn/go-sqlite3 v1.14.16 h1:yOQRA0RpS5PFz/oikGwBEqvAWhWg5ufRz4ETLjwpU1Y=
 github.com/mattn/go-sqlite3 v1.14.16/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=

--- a/repo_db_mirror.go
+++ b/repo_db_mirror.go
@@ -11,6 +11,8 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/klauspost/compress/zstd"
 )
 
 // Uncompresses a gzip file
@@ -21,6 +23,37 @@ func uncompressGZ(filePath string, targetFile string) error {
 		return err
 	}
 	reader, err := gzip.NewReader(gzipfile)
+	if err != nil {
+		log.Printf("error: %v\n", err)
+		return err
+	}
+	limitedReader := io.LimitReader(reader, 100*1024*1024) // Limits the size of the extracted file up to 100MB, so far community db is around 20MB
+	if err != nil {
+		log.Printf("error: %v\n", err)
+		return err
+	}
+	defer reader.Close()
+	writer, err := os.Create(targetFile)
+	if err != nil {
+		log.Printf("error: %v\n", err)
+		return err
+	}
+	defer writer.Close()
+	if _, err = io.Copy(writer, limitedReader); err != nil {
+		log.Printf("error: %v\n", err)
+		return err
+	}
+	return nil
+}
+
+// Uncompress a zstd file
+func uncompressZSTD(filePath string, targetFile string) error {
+	zstdfile, err := os.Open(filePath)
+	if err != nil {
+		log.Printf("error: %v\n", err)
+		return err
+	}
+	reader, err := zstd.NewReader(zstdfile)
 	if err != nil {
 		log.Printf("error: %v\n", err)
 		return err
@@ -125,7 +158,10 @@ func downloadAndParseDb(mirror MirrorDB) error {
 	log.Printf("Extracting %v...", filePath)
 	// the db file exists and have been downloaded. Now it is time to decompress it
 	if err := uncompressGZ(filePath, filePath+".tar"); err != nil {
-		return err
+		log.Printf("Gzip extraction failed with error '%v', attempting zstd extraction...", err)
+		if err := uncompressZSTD(filePath, filePath+".tar"); err != nil {
+			return err
+		}
 	}
 	// delete the original file
 	if err := os.Remove(filePath); err != nil {


### PR DESCRIPTION
Try zstd decompression as fallback (#48). It is structured as for the gzip decompression, to avoid zstd bombs (see [this kind of issues](https://github.com/Shopify/sarama/issues/1831))