### PR TITLE
fix double slash in upstreamURL

### DIFF
--- a/downloader.go
+++ b/downloader.go
@@ -393,11 +393,7 @@ func (f *RequestedFile) key() string {
 }
 
 func (f *RequestedFile) urlPath() string {
-	if f.pathAtRepo == "" {
-		return "/" + f.fileName
-	} else {
-		return f.pathAtRepo + "/" + f.fileName
-	}
+  return f.pathAtRepo+"/"+f.fileName
 }
 
 // mkCacheDir creates cache directory if one does not exist

--- a/downloader.go
+++ b/downloader.go
@@ -76,7 +76,7 @@ func (d *Downloader) download() error {
 }
 
 func (d *Downloader) downloadFromUpstream(repoURL string) error {
-	upstreamURL := repoURL + "/" + d.urlPath
+	upstreamURL := repoURL + d.urlPath
 
 	var req *http.Request
 	var err error
@@ -389,12 +389,12 @@ func (f *RequestedFile) getRepo() *Repo {
 
 // key used for downloaders map; each active Downloader is referenced by its key
 func (f *RequestedFile) key() string {
-	return f.repoName + "/" + f.urlPath()
+	return f.repoName + f.urlPath()
 }
 
 func (f *RequestedFile) urlPath() string {
 	if f.pathAtRepo == "" {
-		return f.fileName
+		return "/" + f.fileName
 	} else {
 		return f.pathAtRepo + "/" + f.fileName
 	}

--- a/downloader.go
+++ b/downloader.go
@@ -393,7 +393,7 @@ func (f *RequestedFile) key() string {
 }
 
 func (f *RequestedFile) urlPath() string {
-  return f.pathAtRepo+"/"+f.fileName
+	return f.pathAtRepo + "/" + f.fileName
 }
 
 // mkCacheDir creates cache directory if one does not exist

--- a/downloader_test.go
+++ b/downloader_test.go
@@ -104,3 +104,41 @@ func TestParallelDownload(t *testing.T) {
 
 	counter.Wait()
 }
+
+func TestRequestedFile(t *testing.T) {
+	path := "/repo/noPath/foobar-3.3.6-7-x86_64.pkg.tar.zst"
+
+	f, err := parseRequestURL(path)
+	if err != nil {
+		t.Error(err)
+	}
+	if f.urlPath() != "/foobar-3.3.6-7-x86_64.pkg.tar.zst" {
+		t.Errorf("expected '%s; got '%s", "/foobar-3.3.6-7-x86_64.pkg.tar.zst", f.urlPath())
+	}
+	if f.key() != "noPath/foobar-3.3.6-7-x86_64.pkg.tar.zst" {
+		t.Errorf("expected '%s; got '%s", "noPath/foobar-3.3.6-7-x86_64.pkg.tar.zst", f.key())
+	}
+	path = "/repo/extened/path/bar-222.pkg.tar.zst"
+	f, err = parseRequestURL(path)
+	if err != nil {
+		t.Error(err)
+	}
+	if f.urlPath() != "/path/bar-222.pkg.tar.zst" {
+		t.Errorf("expected '%s; got '%s", "/path/bar-222.pkg.tar.zst", f.urlPath())
+	}
+	if f.key() != "extened/path/bar-222.pkg.tar.zst" {
+		t.Errorf("expected '%s; got '%s", "extened/path/bar-222.pkg.tar.zst", f.key())
+	}
+	path = "/repo/upstream/extra/os/x86_64/linux-5.19.pkg.tar.zst"
+	f, err = parseRequestURL(path)
+	if err != nil {
+		t.Error(err)
+	}
+	if f.urlPath() != "/extra/os/x86_64/linux-5.19.pkg.tar.zst" {
+		t.Errorf("expected '%s; got '%s", "/extra/os/x86_64/linux-5.19.pkg.tar.zst", f.urlPath())
+	}
+	if f.key() != "upstream/extra/os/x86_64/linux-5.19.pkg.tar.zst" {
+		t.Errorf("expected '%s; got '%s", "upstream/extra/os/x86_64/linux-5.19.pkg.tar.zst", f.key())
+	}
+
+}

--- a/downloader_test.go
+++ b/downloader_test.go
@@ -140,5 +140,4 @@ func TestRequestedFile(t *testing.T) {
 	if f.key() != "upstream/extra/os/x86_64/linux-5.19.pkg.tar.zst" {
 		t.Errorf("expected '%s; got '%s", "upstream/extra/os/x86_64/linux-5.19.pkg.tar.zst", f.key())
 	}
-
 }


### PR DESCRIPTION
pathRegex segments the url into 3 sections, the `pathAtRepo` being for example `/extra/os/x86_64`, package never has a `/` in front.
`urlPath` would return a string without `/` in front if `pathAtRepo` was an empty string, the adding `/` in front was required. But if `pathAtRepo` had a value the added `/` would result in `//extra/os/x86_64` as a prefix.

This PR corrects that behavior so it always returns a string starting with `/`.