### PR TITLE
Build multi-arch docker images

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -5,55 +5,164 @@ on:
   workflow_dispatch:
   push:
 
+env:
+  PLATFORMS: |-
+    linux/amd64
+    linux/arm64
+    linux/arm/v7
+  REGISTRY: ghcr.io
+  IMAGE: ${{ github.repository }}
+
 jobs:
-  test:
+  generate-matrix:
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.generate-matrix.outputs.matrix }}
+    steps:
+      - id: generate-matrix
+        shell: bash
+        run: |
+          echo -n "matrix=" >> $GITHUB_OUTPUT
+          # Output a JSON list containing all PLATFORMS
+          echo "${{ env.PLATFORMS }}" | \
+            jq -R -c '[{ platform: . }]' | \
+            jq -n '{ platforms: [ [inputs[0].platform] ] | add}.platforms' -c >> $GITHUB_OUTPUT
+
+  test:
+    needs:
+      - generate-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      # Use matrix to speed up tests
+      matrix:
+        platform: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v3
-        with:
-          go-version: '^1.17.13'
-          cache: true
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
       - name: Run tests
-        run: go test
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          target: test
+          push: false
+          platforms: ${{ matrix.platform }}
+          # Enable cache to speed up builds
+          # Scope is to ensure that images don't overwrite each other's cache
+          outputs: type=cacheonly
+          cache-from: type=gha,scope=${{ env.REGISTRY }}-${{ github.ref_name }}-${{ matrix.platform }}-tests
+          cache-to: type=gha,mode=max,scope=${{ env.REGISTRY }}-${{ github.ref_name }}-${{ matrix.platform }}-tests
 
-      - name: Build
-        run: go build
-
-  publish_latest:
-    if: github.ref == 'refs/heads/master'
-
+  build:
     runs-on: ubuntu-latest
+    strategy:
+      # Use matrix to speed up builds
+      matrix:
+        platform: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
+
     needs:
+      - generate-matrix
       - test
 
     steps:
       - uses: actions/checkout@v3
 
-      - name: publish master to latest
-        uses: macbre/push-to-ghcr@master
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
         with:
-          image_name: ${{ github.repository }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          image_tag: latest
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE }}
 
-  publish_release:
-    if: startsWith(github.ref, 'refs/tags/v')
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          # Enable cache to speed up builds
+          # Scope is to ensure that images don't overwrite each other's cache
+          cache-from: type=gha,scope=${{ env.REGISTRY }}-${{ github.ref_name }}-${{ matrix.platform }}-executable
+          cache-to: type=gha,mode=max,scope=${{ env.REGISTRY }}-${{ github.ref_name }}-${{ matrix.platform }}-executable
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+
+  merge_and_publish:
+    if: (github.ref == 'refs/heads/master') || (startsWith(github.ref, 'refs/tags/'))
     runs-on: ubuntu-latest
-
     needs:
-      - test
+      - build
 
     steps:
-      - uses: actions/checkout@v3
-
-      - name: publish release to tag
-        uses: macbre/push-to-ghcr@master
+      - name: Download digests
+        uses: actions/download-artifact@v3
         with:
-          image_name: ${{ github.repository }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          image_tag: ${{ github.ref_name }}
+          name: digests
+          path: /tmp/digests
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE }}
+          tags: |
+            # tag tags with :tag
+            type=ref,event=tag
+            # tag default branch with :latest
+            type=raw,value=latest,enable={{is_default_branch}}
+          flavor: |
+            # Do not tag tags with :latest
+            latest=false
+
+      - name: Login to Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ steps.meta.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine3.18 as build
+FROM golang:alpine3.18 AS common
 
 RUN apk add gcc libc-dev
 
@@ -8,9 +8,13 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY *.go ./
 
+FROM common AS test
+RUN go test -ldflags="-s -w"
+
+FROM common AS build
 RUN go build -ldflags="-s -w"
 
-FROM alpine:3.18
+FROM alpine:3.18 AS executable
 
 RUN apk add tzdata
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ RUN apk add gcc libc-dev
 
 WORKDIR /build
 
-COPY . .
+COPY go.mod go.sum ./
+RUN go mod download
+COPY *.go ./
 
 RUN go build -ldflags="-s -w"
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Then start its systemd service: `# systemctl start pacoloco`.
 Pacoloco can be used with docker.
 
 You can get a prebuilt image from GitHub's [container registry](https://github.com/anatol/pacoloco/pkgs/container/pacoloco) (see also sidebar).
-Currently only amd64 is supported.
+Currently the images are built for `amd64` and ARM (`arm64`, `armv7`) architectures.
 ```sh
 docker pull ghcr.io/anatol/pacoloco
 ```


### PR DESCRIPTION
Resolves https://github.com/anatol/pacoloco/issues/89

This MR adds support for building AMD64,ARM64,ARMv7 (the list can be easily extended) images as part of the CI flow.

Few notes:
* tests also had to be dockerized, due to sql library depending on CGO_ENABLED=1
* the images are built in parallel and merged in a separate job to speed up the process, but using qemu still causes the whole pipeline to take around 40 minutes for new code (for ARM, roughly 20 minutes for test and 20 for build). This concept is based on [Docker docs](https://docs.docker.com/build/ci/github-actions/multi-platform/)
* due to GH Actions limitations (`matrix` jobs can not use `env` variables), a bootstrap `generate-matrix` job was added. Its role is to output a list of `PLATFORMS` defined in `env` in a way that can be consumed by `matrix` for parallel builds. [docs](https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson)

Tagging scheme:
* default branch pushes get `:latest`
* tag pushes get `:<tag>`
* any other branch pushes will run the tests and builds, but won't tag the built image

[Example run](https://github.com/dezeroku/pacoloco/actions/runs/5832675885)
