### PR TITLE
Fix example docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ services:
       - /path/to/config/pacoloco.yaml:/etc/pacoloco.yaml
     restart: unless-stopped
 #   to set time zone within the container for cron and log timestamps:
-#    environement:
+#    environment:
 #      - TZ=Europe/Berlin
 ```
 


### PR DESCRIPTION
`environment` was spelled wrong in the example docker-compose file. This caused a several minute detour trying to find what the heck was wrong with the file :o 