### PR TITLE
Sanitize image name in workflow

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -4,6 +4,12 @@ name: Build and push to ghcr.io
 on:
   workflow_dispatch:
   push:
+    paths:
+      - '**.go'
+      - 'go.sum'
+      - 'go.mod'
+      - 'Dockerfile'
+      - '.github/workflows/push.yaml'
 
 env:
   PLATFORMS: |-

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -135,7 +135,6 @@ jobs:
 
 
   merge_and_publish:
-    if: (github.ref == 'refs/heads/master') || (startsWith(github.ref, 'refs/tags/'))
     runs-on: ubuntu-latest
     needs:
       - build
@@ -166,6 +165,8 @@ jobs:
           tags: |
             # tag tags with :tag
             type=ref,event=tag
+            # tag branches with :branch
+            type=ref,event=branch
             # tag default branch with :latest
             type=raw,value=latest,enable={{is_default_branch}}
           flavor: |

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -79,6 +79,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      # Spec requires ref to be lowercase, but
+      # user/org/repo name may have mixed case
+      - name: Sanitize image ref
+        uses: ASzc/change-string-case-action@v6
+        id: ref
+        with:
+          string: ${{ env.REGISTRY }}/${{ env.IMAGE }}
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -105,7 +113,7 @@ jobs:
           context: .
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ steps.ref.outputs.lowercase }},push-by-digest=true,name-canonical=true,push=true
           # Enable cache to speed up builds
           # Scope is to ensure that images don't overwrite each other's cache
           cache-from: type=gha,scope=${{ env.REGISTRY }}-${{ github.ref_name }}-${{ matrix.platform }}-executable
@@ -142,6 +150,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      # Spec requires ref to be lowercase, but
+      # user/org/repo name may have mixed case
+      - name: Sanitize image ref
+        uses: ASzc/change-string-case-action@v6
+        id: ref
+        with:
+          string: ${{ env.REGISTRY }}/${{ env.IMAGE }}
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -167,8 +183,8 @@ jobs:
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE }}@sha256:%s ' *)
+            $(printf '${{ steps.ref.outputs.lowercase }}@sha256:%s ' *)
 
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ${{ steps.ref.outputs.lowercase }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
The push workflow breaks on forks with any uppercase characters in either the user/org or repo name.
This is because container registries require that the image refs are all lowercase, and while docker/metadata-action usually handles that for generated tags, the multi-arch build juggles the images around a bit before assigning a tag, so it uses the raw image name derived from the qualified repo name.

This adds steps to explicitly convert the image name to lowercase.
Additionally, it includes 2 minor changes to the workflow:
- Only run the workflow if any code actually changed
- Always tag images with the branch name

I will drop the latter if you think it's a bad idea, but it seems useful for easier testing of branches. Besides that, I'd suggest reverting to the docker actions' default behavior of having :latest track the latest release, while :master can track all commits to master. While there hasn't been a release yet since the container images were added, having :latest track releases is more useful for end-users (and having tags for branches is nice for devs).