### PR TITLE
Print user IDs instead of usernames in config sanity checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ Alternatively, you can use docker-compose:
 version: "3.8"
 services:
   pacoloco:
+#   if a specific user id is provided, you have to make sure
+#   the mounted directories have the same user id owner on host
+#   user: 1000:1000
     container_name: pacoloco
 #   to pull the image from github's registry:
     image: ghcr.io/anatol/pacoloco

--- a/config.go
+++ b/config.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"log"
-	"os/user"
+	"os"
 	"time"
 
 	"github.com/gorhill/cronexpr"
@@ -73,11 +73,7 @@ func parseConfig(raw []byte) *Config {
 		}
 		// validate Mirrorlist config
 		if repo.Mirrorlist != "" && unix.Access(repo.Mirrorlist, unix.R_OK) != nil {
-			u, err := user.Current()
-			if err != nil {
-				log.Fatal(err)
-			}
-			log.Fatalf("mirrorlist file %v for repo %v does not exist or isn't readable for user %v", repo.Mirrorlist, name, u.Username)
+			log.Fatalf("mirrorlist file %v for repo %v does not exist or isn't readable for userid %v", repo.Mirrorlist, name, os.Getuid())
 		}
 	}
 
@@ -86,11 +82,7 @@ func parseConfig(raw []byte) *Config {
 	}
 
 	if unix.Access(result.CacheDir, unix.R_OK|unix.W_OK) != nil {
-		u, err := user.Current()
-		if err != nil {
-			log.Fatal(err)
-		}
-		log.Fatalf("directory %v does not exist or isn't writable for user %v", result.CacheDir, u.Username)
+		log.Fatalf("directory %v does not exist or isn't writable for userid %v", result.CacheDir, os.Getuid())
 	}
 	// validate Prefetch config
 


### PR DESCRIPTION
This resolves https://github.com/anatol/pacoloco/issues/99

With the current implementation sanity checks will fail when running the docker container as an arbitrary user (e.g. with `user: 1001:1001` in `docker-compose.yml`):
```
 config.go:91: user: unknown userid 1001
```

This happens because the `os/user` implementation of `Current()` (see a similar [issue](https://github.com/golang/go/issues/38599)) tries to obtain the user info based on `/etc/passwd` file and entry in it is not created when running a container with a specific UID:GID.

This PR changes it so UID is printed instead of the username, thus fixing the issue.



On a sidenote, we can try to get the username and fallback to printing just the user id. I am not sure if it's cleaner than going straight to the user IDs though.