### PR TITLE
Support per-repo http_proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ repos:
   quarry:
     url: http://pkgbuild.com/~anatolik/quarry/x86_64
   sublime:
+    http_proxy: http://bar.company.com:8989 # Proxy could be enabled per-repo, shadowing the global `http_proxy` (see below)
     url: https://download.sublimetext.com/arch/stable/x86_64
   archlinux-reflector:
     mirrorlist: /etc/pacman.d/reflector_mirrorlist # Be careful! Check that pacoloco URL is NOT included in that file!
@@ -116,7 +117,7 @@ prefetch: # optional section, add it if you want to enable prefetching
 * `purge_files_after` specifies inactivity duration (in seconds) after which the file should be removed from the cache. This functionality uses unix "AccessTime" field to find out inactive files. Default value is `0` that means never run the purging.
 * `port` is the server port.
 * `download_timeout` is a timeout (in seconds) for internet->cache downloads. If a remote server gets slow and file download takes longer than this will be terminated. Default value is `0` that means no timeout.
-* `repos` is a list of repositories to mirror. Each repo needs `name` and url of its Arch mirrors. Note that url can be specified either with `url` or `urls` properties, one and only one can be used for each repo configuration.
+* `repos` is a list of repositories to mirror. Each repo needs `name` and url of its Arch mirrors. Note that url can be specified either with `url` or `urls` properties, one and only one can be used for each repo configuration. Each repo could have its own `http_proxy`, which would shadow the global `http_proxy` (see below).
 * `http_proxy` is only to be used if you have pacoloco running behind a proxy
 * `user_agent` user agent used to fetch the files from repositories. Default value is `Pacoloco/1.2`.
 * The `prefetch` section allows to enable packages prefetching. Comment it out to disable it.

--- a/config.go
+++ b/config.go
@@ -22,6 +22,7 @@ type Repo struct {
 	URL                  string    `yaml:"url"`
 	URLs                 []string  `yaml:"urls"`
 	Mirrorlist           string    `yaml:"mirrorlist"`
+	HttpProxy            string    `yaml:"http_proxy"`
 	LastMirrorlistCheck  time.Time `yaml:"-"`
 	LastModificationTime time.Time `yaml:"-"`
 }

--- a/pacoloco.yaml.sample
+++ b/pacoloco.yaml.sample
@@ -13,6 +13,7 @@ repos:
     mirrorlist: /etc/pacman.d/mirrorlist ## Be careful! Check that pacoloco URL is NOT included in that file!
 ## Local/3rd party repos can be added following the below example:
 #  quarry:
+#    http_proxy: http://bar.company.com:8989 ## Proxy could be enabled per-repo, shadowing the global `http_proxy` (see below)
 #    url: http://pkgbuild.com/~anatolik/quarry/x86_64
 
 # prefetch: ## optional section, add it if you want to enable prefetching


### PR DESCRIPTION
This adds a feature with which `http_proxy` could be set on a per-repo basis.

This is useful if pacoloco runs on a server where most of the repos it serve are easy to access, but some others are not, e.g.:

E.g. this is my config:
```
repos:
  archlinux:
    urls:
      - http://mirrors.wsyu.edu.cn/archlinux
      - http://mirrors.163.com/archlinux
      - https://mirrors.aliyun.com/archlinux
      - http://mirrors.tuna.tsinghua.edu.cn/archlinux
  archlinuxarm:
    urls:
      - http://mirrors.163.com/archlinuxarm
      - https://mirrors.aliyun.com/archlinuxarm
  archlinuxcn_x86_64:
    urls:
      - http://mirrors.wsyu.edu.cn/archlinucn
      - http://mirrors.163.com/archlinucn
      - https://mirrors.aliyun.com/archlinuxcn
  archlinuxcn_aarch64:
    urls:
      - http://mirrors.wsyu.edu.cn/archlinucn
      - http://mirrors.163.com/archlinucn
      - https://mirrors.aliyun.com/archlinuxcn
  7Ji_x86_64:
    http_proxy: http://proxy.lan:1085
    url: https://github.com/7Ji/archrepo/releases/download
  7Ji_aarch64:
    http_proxy: http://proxy.lan:1085
    url: https://github.com/7Ji/archrepo/releases/download
```
As the config shows, there're mirrors for `archlinux`, `archlinuxcn` and `archlinuxarm` in China so I don't want to set a global `http_proxy` to waste my proxy bandwidth, but repo `7Ji` uses Github releases as storage and it is hard to access without a proxy in China, so I want to use proxy for and only for repo `7Ji`.
