### PR TITLE
Fix network issue and use cache when network is down

### DIFF
--- a/downloader.go
+++ b/downloader.go
@@ -253,6 +253,12 @@ func getDownloadReader(f *RequestedFile) (time.Time, io.ReadSeekCloser, error) {
 	}
 
 	// we are done downloading without correctly received metadata, it is an error
+	// end 'd' properly
+	d.decrementUsage()
+	// if cache exists, use that
+	if f.cachedFileExists() {
+		return time.Time{}, nil, nil
+	}
 	return time.Time{}, nil, d.eventError
 }
 


### PR DESCRIPTION
Relate to https://github.com/anatol/pacoloco/issues/108

I think it's not only an issue with http_proxy. I can reproduce this error without http_proxy settings by plug/unplug my network cable (forcing a connection issue during pacoloco's network activity), same problem will show up.

After a little tinkering I think the problem is `d` is not ended by default. And I added `f.cachedFileExists` so that cache can be served. (Otherwise pacoloco would just return err without sending anything. https://github.com/anatol/pacoloco/blob/master/pacoloco.go#L270)

This has a little bit downside, it would not register a `cacheServingFailedCounter` if cache is sent. But I guess that would not be a fail after all?