### PR TITLE
add listen address

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Optionally you can build the binary from sources using `go build` command.
 The server configuration is located at `/etc/pacoloco.yaml`. Here is an example how the config file looks like:
 
 ```yaml
+address: 127.0.0.1
 port: 9129
 cache_dir: /var/cache/pacoloco
 purge_files_after: 360000 # 360000 seconds or 100 hours, 0 to disable
@@ -115,6 +116,7 @@ prefetch: # optional section, add it if you want to enable prefetching
 
 * `cache_dir` is the cache directory, this location needs to read/writable by the server process.
 * `purge_files_after` specifies inactivity duration (in seconds) after which the file should be removed from the cache. This functionality uses unix "AccessTime" field to find out inactive files. Default value is `0` that means never run the purging.
+* `address` is the servers listening address. When left empty, the server will start opening a listener on all available addresses. When any of the IPs is a public IP, it will make pacoloco available to the internet.
 * `port` is the server port.
 * `download_timeout` is a timeout (in seconds) for internet->cache downloads. If a remote server gets slow and file download takes longer than this will be terminated. Default value is `0` that means no timeout.
 * `repos` is a list of repositories to mirror. Each repo needs `name` and url of its Arch mirrors. Note that url can be specified either with `url` or `urls` properties, one and only one can be used for each repo configuration. Each repo could have its own `http_proxy`, which would shadow the global `http_proxy` (see below).

--- a/config.go
+++ b/config.go
@@ -12,6 +12,7 @@ import (
 )
 
 const (
+	DefaultAddress       = ""
 	DefaultPort          = 9129
 	DefaultCacheDir      = "/var/cache/pacoloco"
 	DefaultTTLUnaccessed = 30
@@ -37,6 +38,7 @@ type RefreshPeriod struct {
 
 type Config struct {
 	CacheDir        string           `yaml:"cache_dir"`
+	Address         string           `yaml:"address"`
 	Port            int              `yaml:"port"`
 	Repos           map[string]*Repo `yaml:"repos,omitempty"`
 	PurgeFilesAfter int              `yaml:"purge_files_after"`
@@ -52,6 +54,7 @@ var config *Config
 func parseConfig(raw []byte) *Config {
 	result := Config{
 		CacheDir: DefaultCacheDir,
+		Address:  DefaultAddress,
 		Port:     DefaultPort,
 		Prefetch: nil,
 	}

--- a/pacoloco.go
+++ b/pacoloco.go
@@ -137,8 +137,8 @@ func main() {
 		config.UserAgent = "Pacoloco/1.2"
 	}
 
-	listenAddr := fmt.Sprintf(":%d", config.Port)
-	log.Println("Starting server at port", config.Port)
+	listenAddr := fmt.Sprintf("%s:%d", config.Address, config.Port)
+	log.Printf("Starting server at address %s:%d", config.Address, config.Port)
 	// The request path looks like '/repo/$reponame/$pathatmirror'
 	http.HandleFunc("/repo/", pacolocoHandler)
 	// Expose prometheus metrics

--- a/pacoloco.yaml.sample
+++ b/pacoloco.yaml.sample
@@ -1,4 +1,5 @@
 # cache_dir: /var/cache/pacoloco
+# address:
 # port: 9129
 download_timeout: 3600 ## downloads will timeout if not completed after 3600 sec, 0 to disable timeout
 purge_files_after: 2592000 ## purge file after 30 days


### PR DESCRIPTION
In some environments listening on all available addresses isn't intended or required.

This adds a new config option to bind the process to only a single address. The default is kept empty to keep the old behavior.