### PR TITLE
Ignore core.db.sig and extra.db.sig download errors

### DIFF
--- a/downloader.go
+++ b/downloader.go
@@ -74,6 +74,11 @@ func (d *Downloader) download() error {
 	for _, u := range urls {
 		err := d.downloadFromUpstream(u, proxyURL)
 		if err != nil {
+			if strings.HasSuffix(u, "/core.db.sig") || strings.HasSuffix(u, "/extra.db.sig") {
+		        	// Archlinux dbs are not signed as of Nov 2024
+        			// https://wiki.archlinux.org/title/DeveloperWiki:Repo_DB_Signing
+        			return nil
+			}
 			log.Printf("unable to download file %v: %v", d.key, err)
 			continue // try next mirror
 		}


### PR DESCRIPTION
I think it safe to assume the behavior is not expected to change anytime soon since it has not changed for decades. 

1. Avoids unnecessary pings to all configured mirror servers
2. Removes the noise from logs

fixes #112