### PR TITLE
Fix .db.sig skip check- don't try to download at all

### DIFF
--- a/downloader.go
+++ b/downloader.go
@@ -71,14 +71,15 @@ func (d *Downloader) download() error {
 		proxyURL = nil
 	}
 
+	// Archlinux dbs are not signed as of Nov 2024
+	// https://wiki.archlinux.org/title/DeveloperWiki:Repo_DB_Signing
+	if strings.HasSuffix(d.urlPath, ".db.sig") {
+		return nil
+	}
+
 	for _, u := range urls {
 		err := d.downloadFromUpstream(u, proxyURL)
 		if err != nil {
-			if strings.HasSuffix(u, "/core.db.sig") || strings.HasSuffix(u, "/extra.db.sig") {
-				// Archlinux dbs are not signed as of Nov 2024
-				// https://wiki.archlinux.org/title/DeveloperWiki:Repo_DB_Signing
-				return nil
-			}
 			log.Printf("unable to download file %v: %v", d.key, err)
 			continue // try next mirror
 		}


### PR DESCRIPTION
RE #128 #126 

This change skips downloading all *.db.sig files.

Rationale to skip downloading :
- Due to how pacoloco treats 404 responses as an error, it needs to send a request to every mirror to give a 404 for a .db.sig request.
- This is slow, in particular it introduces a 10s lag to system upgrade if an old mirror on the list hangs.
- Consistency with pacman: even with a mirror that would hang, pacman doesn't hang for 10s to download sig files.

This change also fixes the log spam about .db.sig files. The prior check added in PR #120 doesn't seem to work since `u` is the upstream URL.