### PR TITLE
Update documentation with information about the `--config` argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,15 @@ Optionally you can build the binary from sources using `go build` command.
 
 ## Configure
 
-The server configuration is located at `/etc/pacoloco.yaml`. Here is an example how the config file looks like:
+The server configuration default location is `/etc/pacoloco.yaml`.
+
+Changing the config file location can be done with the `--config` argument when launching pacoloco, like this:
+
+```sh
+$ pacoloco --config /some/location/config.yaml
+```
+
+Here is an example how the config file looks like:
 
 ```yaml
 port: 9129

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,14 @@
 # Configuration Reference
 
-Pacoloco is configured via a YAML file located at `/etc/pacoloco.yaml`.
+Pacoloco is configured via a YAML file.
+
+The default location of the config file is `/etc/pacoloco.yaml`.
+
+Changing the config file location can be done with the `--config` argument when launching pacoloco, like this:
+
+```sh
+$ pacoloco --config /some/location/config.yaml
+```
 
 ## General Settings
 


### PR DESCRIPTION
Make it clear in the README and config docs that users can launch pacoloco with a different location for the config file