### PR TITLE
fix(helm): remove default repos to enable proper config overrides

### DIFF
--- a/helm/pacoloco/templates/configmap.yaml
+++ b/helm/pacoloco/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.existingConfigurationConfigMap }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,3 +8,4 @@ metadata:
 data:
   pacoloco.yaml: |
 {{ toYaml .Values.configuration | indent 4 }}
+{{- end }}

--- a/helm/pacoloco/templates/deployment.yaml
+++ b/helm/pacoloco/templates/deployment.yaml
@@ -72,10 +72,11 @@ spec:
             claimName: {{ include "pacoloco.fullname" . }}-data
         - name: configfile
           configMap:
+            {{- if .Values.existingConfigurationConfigMap }}
+            name: {{ .Values.existingConfigurationConfigMap }}
+            {{- else }}
             name: {{ include "pacoloco.fullname" . }}-config
-            #items:
-            #  - key: pacoloco.yaml
-            #    path: pacoloco.yaml
+            {{- end }}
       {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm/pacoloco/values.yaml
+++ b/helm/pacoloco/values.yaml
@@ -10,6 +10,8 @@ persistence:
   size: 20Gi
   storageClass: null
 
+existingConfigurationConfigMap: ""
+
 configuration:
   # default configuration from here: https://github.com/anatol/pacoloco#configure
   address:
@@ -18,17 +20,16 @@ configuration:
   cache_dir: /var/cache/pacoloco
   download_timeout: 3600
   purge_files_after: 2592000 ## purge file after 30 days
-  repos:
-    archlinux:
-      urls:
-        - http://mirror.lty.me/archlinux
-        - http://mirrors.kernel.org/archlinux
+  repos: {}
+    #archlinux:
+    #  urls:
+    #    - http://mirror.lty.me/archlinux
+    #    - http://mirrors.kernel.org/archlinux
     #archlinux-reflector:
     #  mirrorlist: /etc/pacman.d/mirrorlist
   prefetch: ## optional section, add it if you want to enable prefetching
-   cron: 0 0 3 * * * * ## standard cron expression (https://en.wikipedia.org/wiki/Cron#CRON_expression) to define how frequently prefetch, see https://github.com/gorhill/cronexpr#implementation for documentation.
-   ttl_unaccessed_in_days: 30
-
+    cron: 0 0 3 * * * * ## standard cron expression (https://en.wikipedia.org/wiki/Cron#CRON_expression) to define how frequently prefetch, see https://github.com/gorhill/cronexpr#implementation for documentation.
+    ttl_unaccessed_in_days: 30
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:
@@ -108,18 +109,18 @@ httpRoute:
   annotations: {}
   # Which Gateways this Route is attached to.
   parentRefs:
-  - name: gateway
-    sectionName: http
-    # namespace: default
+    - name: gateway
+      sectionName: http
+      # namespace: default
   # Hostnames matching HTTP header.
   hostnames:
-  - chart-example.local
+    - chart-example.local
   # List of rules and filters applied.
   rules:
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /headers
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /headers
   #   filters:
   #   - type: RequestHeaderModifier
   #     requestHeaderModifier:


### PR DESCRIPTION
 BREAKING CHANGE: repo defaults removed; config must be supplied explicitly or via external ConfigMap

## Summary

This change fixes an issue where configuration values (especially `repos`) could not be properly overridden when the chart was used as a dependency.  
Previously, embedded default values were always merged, which prevented consumers from fully controlling the configuration.

## What changed

- Support for providing configuration via `existingConfigurationConfigMap`
- Removal of embedded default `repos` configuration
- Other default configuration remains unchanged

## Why

The previous behavior made it impossible to override `repos` due to Helm's merge strategy.  
Even when explicitly setting values, defaults defined in the chart would still be applied.

By removing the default `repos`, the chart now behaves predictably and allows full override of that section.

## Breaking Changes

- Default `repos` configuration has been removed
- Users must now explicitly define `repos` if needed
- This can be done either via:
  - `values.yaml`
  - or `existingConfigurationConfigMap`

## Migration Guide

If you relied on the previous default `repos`, you now need to define them explicitly.

Example:

```yaml
configuration:
  repos:
    archlinux:
      urls:
        - http://mirror.lty.me/archlinux