### PR TITLE
Run container as non-root, modernize Dockerfile and CI caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+# Keep the build context down to what the Dockerfile actually copies
+# (go.mod, go.sum, *.go); everything else only slows context upload and
+# invalidates nothing.
+.git
+.github
+docs
+helm
+*.md
+LICENSE
+pacoloco.service
+pacoloco.sysusers.d
+pacoloco.tmpfiles.d
+pacoloco.yaml.sample

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+---
+version: 2
+updates:
+  # Keeps action majors current.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  # Keeps the digest-pinned base images in the Dockerfile current.
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -11,6 +11,16 @@ on:
       - 'Dockerfile'
       - '.github/workflows/push.yaml'
 
+# Newer pushes to the same branch supersede in-flight builds.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Least-privilege token: pushing images to ghcr.io needs packages: write.
+permissions:
+  contents: read
+  packages: write
+
 env:
   PLATFORMS: |-
     linux/amd64
@@ -28,11 +38,11 @@ jobs:
       - id: generate-matrix
         shell: bash
         run: |
-          echo -n "matrix=" >> $GITHUB_OUTPUT
+          echo -n "matrix=" >> "$GITHUB_OUTPUT"
           # Output a JSON list containing all PLATFORMS
           echo "${{ env.PLATFORMS }}" | \
             jq -R -c '[{ platform: . }]' | \
-            jq -n '{ platforms: [ [inputs[0].platform] ] | add}.platforms' -c >> $GITHUB_OUTPUT
+            jq -n '{ platforms: [ [inputs[0].platform] ] | add}.platforms' -c >> "$GITHUB_OUTPUT"
 
   test:
     needs:
@@ -44,26 +54,54 @@ jobs:
         platform: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
+
+      # Persist the Dockerfile's /root/.cache/go-build cache mount across CI
+      # runs. The GHA layer cache below only replays fully unchanged layers;
+      # this keeps compilation incremental when the source *does* change.
+      # The same key is shared with the build job (test runs first and saves,
+      # build gets an exact hit and skips re-saving).
+      - name: Go build cache
+        id: go-cache
+        uses: actions/cache@v6
+        with:
+          path: go-build-cache
+          key: go-build-cache-${{ matrix.platform }}-${{ hashFiles('**/go.sum') }}-${{ github.sha }}
+          restore-keys: |
+            go-build-cache-${{ matrix.platform }}-${{ hashFiles('**/go.sum') }}-
+            go-build-cache-${{ matrix.platform }}-
+
+      - name: Inject go-build cache into BuildKit
+        uses: reproducible-containers/buildkit-cache-dance@v3
+        with:
+          cache-map: |
+            {
+              "go-build-cache": "/root/.cache/go-build"
+            }
+          skip-extraction: ${{ steps.go-cache.outputs.cache-hit }}
 
       - name: Run tests
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           context: .
           target: test
           push: false
           platforms: ${{ matrix.platform }}
-          # Enable cache to speed up builds
-          # Scope is to ensure that images don't overwrite each other's cache
           outputs: type=cacheonly
-          cache-from: type=gha,scope=${{ env.REGISTRY }}-${{ github.ref_name }}-${{ matrix.platform }}-tests
-          cache-to: type=gha,mode=max,scope=${{ env.REGISTRY }}-${{ github.ref_name }}-${{ matrix.platform }}-tests
+          # One layer-cache scope per branch and platform, shared between the
+          # test and build jobs so the build job reuses the common stage
+          # layers the test job already produced. The default-branch scope is
+          # the read fallback for freshly created branches.
+          cache-from: |
+            type=gha,scope=${{ env.REGISTRY }}-${{ github.ref_name }}-${{ matrix.platform }}
+            type=gha,scope=${{ env.REGISTRY }}-${{ github.event.repository.default_branch }}-${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ env.REGISTRY }}-${{ github.ref_name }}-${{ matrix.platform }}
 
   build:
     runs-on: ubuntu-latest
@@ -77,47 +115,66 @@ jobs:
       - test
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       # Spec requires ref to be lowercase, but
       # user/org/repo name may have mixed case
       - name: Sanitize image ref
-        uses: ASzc/change-string-case-action@v6
         id: ref
-        with:
-          string: ${{ env.REGISTRY }}/${{ env.IMAGE }}
+        env:
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE }}
+        run: echo "lowercase=${IMAGE_REF,,}" >> "$GITHUB_OUTPUT"
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Go build cache
+        id: go-cache
+        uses: actions/cache@v6
+        with:
+          path: go-build-cache
+          key: go-build-cache-${{ matrix.platform }}-${{ hashFiles('**/go.sum') }}-${{ github.sha }}
+          restore-keys: |
+            go-build-cache-${{ matrix.platform }}-${{ hashFiles('**/go.sum') }}-
+            go-build-cache-${{ matrix.platform }}-
+
+      - name: Inject go-build cache into BuildKit
+        uses: reproducible-containers/buildkit-cache-dance@v3
+        with:
+          cache-map: |
+            {
+              "go-build-cache": "/root/.cache/go-build"
+            }
+          skip-extraction: ${{ steps.go-cache.outputs.cache-hit }}
+
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ steps.ref.outputs.lowercase }},push-by-digest=true,name-canonical=true,push=true
-          # Enable cache to speed up builds
-          # Scope is to ensure that images don't overwrite each other's cache
-          cache-from: type=gha,scope=${{ env.REGISTRY }}-${{ github.ref_name }}-${{ matrix.platform }}-executable
-          cache-to: type=gha,mode=max,scope=${{ env.REGISTRY }}-${{ github.ref_name }}-${{ matrix.platform }}-executable
+          cache-from: |
+            type=gha,scope=${{ env.REGISTRY }}-${{ github.ref_name }}-${{ matrix.platform }}
+            type=gha,scope=${{ env.REGISTRY }}-${{ github.event.repository.default_branch }}-${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ env.REGISTRY }}-${{ github.ref_name }}-${{ matrix.platform }}
 
       - name: Export digest
         run: |
@@ -126,16 +183,15 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
           PLATFORM=${{ matrix.platform }}
           # Replace slashes in platform name with dashes
-          echo "PLATFORM_ARTIFACT=${PLATFORM//\//-}" >> $GITHUB_ENV
+          echo "PLATFORM_ARTIFACT=${PLATFORM//\//-}" >> "$GITHUB_ENV"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digests-${{ env.PLATFORM_ARTIFACT }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
-
 
   merge_and_publish:
     runs-on: ubuntu-latest
@@ -144,26 +200,26 @@ jobs:
 
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: digests-*
           merge-multiple: true
           path: /tmp/digests
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
 
       # Spec requires ref to be lowercase, but
       # user/org/repo name may have mixed case
       - name: Sanitize image ref
-        uses: ASzc/change-string-case-action@v6
         id: ref
-        with:
-          string: ${{ env.REGISTRY }}/${{ env.IMAGE }}
+        env:
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE }}
+        run: echo "lowercase=${IMAGE_REF,,}" >> "$GITHUB_OUTPUT"
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE }}
           tags: |
@@ -178,7 +234,7 @@ jobs:
             latest=false
 
       - name: Login to Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -187,6 +243,9 @@ jobs:
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
+          # Word splitting is intentional: expands to multiple `-t <tag>`
+          # flags and one digest ref per file.
+          # shellcheck disable=SC2046
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ steps.ref.outputs.lowercase }}@sha256:%s ' *)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,78 @@
-FROM golang:alpine3.23 AS common
+# syntax=docker/dockerfile:1
 
-RUN apk add gcc libc-dev
+# Multi-stage build for pacoloco.
+#
+# Targets:
+#   test        run the Go test suite (used by CI, per target platform)
+#   build       compile the release binary
+#   dev         full toolchain for development; mount the source and the Go
+#               caches to iterate quickly:
+#                 docker build --target dev -t pacoloco:dev .
+#                 docker run --rm -it \
+#                   -v "$PWD":/build \
+#                   -v pacoloco-gomod:/go/pkg/mod \
+#                   -v pacoloco-gobuild:/root/.cache/go-build \
+#                   -v "$PWD"/pacoloco.yaml:/etc/pacoloco.yaml:ro \
+#                   -p 9129:9129 pacoloco:dev
+#   executable  (default) runtime image, runs as non-root uid 65532
+#
+# Base images are pinned by digest for reproducibility; bump the tag and the
+# digest together (Dependabot keeps both updated).
+
+# Toolchain pinned to the Go version required by go.mod.
+FROM golang:1.25-alpine3.23@sha256:60e626bbde32def8694687d03536ea4341b19e5f068e9a630225a1dfbd0505c9 AS common
+
+# gcc/libc-dev: cgo toolchain for the sqlite driver. Package versions ride
+# the pinned base image digest instead of apk pins, which Alpine mirrors
+# break by dropping old package revisions.
+# hadolint ignore=DL3018
+RUN apk add --no-cache gcc libc-dev
 
 WORKDIR /build
 
+# Modules in their own layer: source edits don't invalidate the download,
+# and the layer is restorable from registry/GHA layer caches.
 COPY go.mod go.sum ./
 RUN go mod download
+
 COPY *.go ./
 
+# The go-build cache mount persists compiled objects across builds (locally
+# via BuildKit state, in CI via buildkit-cache-dance), so incremental
+# rebuilds only recompile changed packages.
 FROM common AS test
-RUN go test -ldflags="-s -w"
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    go test -trimpath -ldflags="-s -w"
+
+FROM common AS dev
+CMD ["go", "run", "."]
 
 FROM common AS build
-RUN go build -ldflags="-s -w"
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    go build -trimpath -ldflags="-s -w"
 
-FROM alpine:3.23 AS executable
+FROM alpine:3.23@sha256:fd791d74b68913cbb027c6546007b3f0d3bc45125f797758156952bc2d6daf40 AS executable
 
-RUN apk add tzdata
+LABEL org.opencontainers.image.title="pacoloco" \
+      org.opencontainers.image.description="Caching proxy server for Arch Linux pacman repositories" \
+      org.opencontainers.image.source="https://github.com/anatol/pacoloco" \
+      org.opencontainers.image.licenses="MIT"
+
+# tzdata: TZ support for prefetch cron schedules and log timestamps.
+# The image runs as the dedicated non-root user 65532 ("nonroot" convention);
+# the cache directory is pre-created with matching ownership so the container
+# works out of the box, with or without a mounted volume.
+# hadolint ignore=DL3018
+RUN apk add --no-cache tzdata \
+ && addgroup -g 65532 pacoloco \
+ && adduser -D -H -u 65532 -G pacoloco -s /sbin/nologin pacoloco \
+ && install -d -o pacoloco -g pacoloco /var/cache/pacoloco
 
 WORKDIR /pacoloco
 
 COPY --from=build /build/pacoloco .
+
+USER 65532:65532
 
 EXPOSE 9129
 

--- a/README.md
+++ b/README.md
@@ -70,13 +70,19 @@ $ docker run -p 9129:9129 \
 ```
 You need to provide paths or volumes to store application data.
 
+The container runs as the non-root user `65532` by default. When
+bind-mounting a host directory for the cache, make it writable for that
+uid (`chown 65532:65532 /path/to/cache`) or override the user with
+`--user "$(id -u):$(id -g)"`.
+
 Alternatively, you can use docker-compose:
 ```yaml
 ---
 services:
   pacoloco:
-#   if a specific user id is provided, you have to make sure
-#   the mounted directories have the same user id owner on host
+#   the image runs as uid/gid 65532 by default; if another user id is
+#   provided, you have to make sure the mounted directories have the same
+#   user id owner on host
 #   user: 1000:1000
     container_name: pacoloco
 #   to pull the image from github's registry:
@@ -93,6 +99,11 @@ services:
 #    environment:
 #      - TZ=Europe/Berlin
 ```
+
+
+See the [chart documentation](helm/pacoloco/README.md) for persistence,
+Ingress/Gateway API exposure, Prometheus monitoring and the full values
+reference.
 
 ## Build from sources
 

--- a/README.md
+++ b/README.md
@@ -100,11 +100,6 @@ services:
 #      - TZ=Europe/Berlin
 ```
 
-
-See the [chart documentation](helm/pacoloco/README.md) for persistence,
-Ingress/Gateway API exposure, Prometheus monitoring and the full values
-reference.
-
 ## Build from sources
 
 Requires Go 1.25.0 or later.


### PR DESCRIPTION
## What

Two focused commits: the Docker image now runs as a non-root user, and the build workflow gets current action versions plus caching that actually persists between runs. No changes to pacoloco itself.

## Docker image (`build(docker)`)

- The final image runs as a dedicated non-root user, uid/gid **65532**. The cache directory is pre-created with matching ownership, so the container works out of the box both with a named volume and without any volume at all.
- Base images are pinned by tag **and digest** (Dependabot keeps the digests fresh, see below).
- `apk add --no-cache`, `-trimpath`, and a BuildKit `go-build` cache mount for the test/build stages - incremental rebuilds only recompile what changed (locally: ~58s → ~2s after a one-line source edit).
- New `dev` target with the full toolchain: bind-mount the source and Go caches, get a fast edit-run loop. Usage is documented at the top of the Dockerfile.
- OCI image labels and a `.dockerignore` (build context no longer includes `.git`, docs, etc).
- README: documented the runtime uid and what it means for bind mounts.

Stage names (`test`, `build`, final) and the binary path `/pacoloco/pacoloco` are unchanged, so the existing workflow and compose files keep working.

### ⚠ Behaviour change

Anyone bind-mounting a host directory for the cache needs it writable by uid 65532 (`chown 65532:65532 /path/to/cache`) or has to override the user (`--user "$(id -u):$(id -g)"`, or `user:` in compose). Named volumes and volume-less runs are unaffected. This also gives a clear answer to the "which user does the container run as?" question that came up in #118.

## CI (`ci`)

- All actions bumped to current majors: `checkout@v7`, `build-push-action@v7`, `metadata-action@v6`, `upload/download-artifact@v7/v8`, `setup-qemu/buildx/login@v4`.
- Dropped the third-party `ASzc/change-string-case-action`; lowercasing is one line of bash now.
- Added a least-privilege `permissions:` block and `concurrency` so a newer push cancels superseded runs.
- Layer cache: test and build jobs previously wrote to separate GHA cache scopes, so shared layers were duplicated and never reused across jobs. Now there is one scope per branch+platform (test populates, build reuses) with a default-branch fallback for new branches.
- The `go-build` cache mount is persisted across CI runs via `reproducible-containers/buildkit-cache-dance` — layer cache only helps when nothing changed; this keeps compilation incremental when the source *did* change, which is especially noticeable for the QEMU-emulated arm builds.
- New `.github/dependabot.yml` covering `github-actions` and `docker` (the latter maintains the Dockerfile digest pins).

## Testing

- `docker build --target test .` passes for the release toolchain; image builds for amd64/arm64/arm-v7.
- Runtime smoke as uid 65532: `/metrics` responds, a real package database download through the cache works (HTTPS mirror), the prefetch sqlite DB is created on the volume with correct ownership, `TZ` is honoured.
- `hadolint`: clean; `trivy image`: 0 vulnerabilities; `actionlint` on the workflow: 0 findings.

Related: #118 (runtime user question).