### PR TITLE
Fix races, hangs and error handling in the download path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,10 @@ updates:
     schedule:
       interval: weekly
     # Wait out fresh releases so yanked/compromised versions never land.
+    # Only default-days here: semver-* cooldowns are unsupported for the
+    # github-actions and docker ecosystems.
     cooldown:
       default-days: 7
-      semver-major-days: 14
     groups:
       github-actions:
         patterns:
@@ -22,7 +23,6 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
-      semver-major-days: 14
     groups:
       docker-images:
         patterns:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -122,7 +122,7 @@ The downloader subsystem (`downloader.go`) is the core data path. It uses `sync.
 
 5. **`DownloadReader`** -- Implements `io.ReadSeekCloser` to provide a streaming interface. Multiple HTTP response writers can read from the same download concurrently, each tracking their own read position while the background goroutine writes ahead.
 
-6. **Cleanup** -- An atomic `usageCount` tracks the number of active readers. When the last reader closes, the `Downloader` is removed from the active downloads map.
+6. **Cleanup** -- A `usageCount` guarded by `downloadersMutex` tracks the number of active readers. When the last reader closes, the `Downloader` is removed from the active downloads map and its buffer file is deleted, atomically with respect to new readers attaching.
 
 ## 7. Configuration
 

--- a/downloader.go
+++ b/downloader.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 )
 
@@ -34,7 +33,13 @@ type Downloader struct {
 	repo     *Repo
 	urlPath  string // path + filename
 
-	usageCount atomic.Int32 // number of users that keep using the Downloader
+	// usageCount is the number of active users of this Downloader: every
+	// client streaming from it plus the download goroutine itself. It is
+	// guarded by downloadersMutex: the transition to zero and the removal
+	// from downloaders must be atomic with respect to attaching in
+	// getDownloader, otherwise a client could attach to a Downloader whose
+	// buffer file is already being cleaned up.
+	usageCount int
 
 	eventCond             *sync.Cond // sync point for receiving events, such as (error, metadataReceived, dataReceived, done)
 	eventError            error
@@ -45,16 +50,19 @@ type Downloader struct {
 }
 
 func (d *Downloader) decrementUsage() {
-	val := d.usageCount.Add(-1)
+	downloadersMutex.Lock()
+	defer downloadersMutex.Unlock()
 
-	if val == 0 {
-		downloadersMutex.Lock()
-		defer downloadersMutex.Unlock()
-
-		delete(downloaders, d.key)
-		_ = d.bufferFile.Close()
-		_ = os.Remove(d.bufferFile.Name())
+	d.usageCount--
+	if d.usageCount > 0 {
+		return
 	}
+
+	// Last user: nobody can attach anymore once the Downloader is removed
+	// from the map, so releasing the buffer file here is safe.
+	delete(downloaders, d.key)
+	_ = d.bufferFile.Close()
+	_ = os.Remove(d.bufferFile.Name())
 }
 
 func (d *Downloader) download() error {
@@ -351,10 +359,10 @@ func getDownloader(f *RequestedFile) (*Downloader, error) {
 			repo:           config.Repos[f.repoName],
 			eventCond:      cond,
 		}
-		d.usageCount.Add(1) // one downloader is in use by the caller
+		d.usageCount++ // one downloader is in use by the caller
 		downloaders[key] = d
 
-		d.usageCount.Add(1) // one downloader is in use by download() function
+		d.usageCount++ // one downloader is in use by download() function
 		// start downloading the data asynchronously
 		go func() {
 			err := d.download()
@@ -371,7 +379,7 @@ func getDownloader(f *RequestedFile) (*Downloader, error) {
 			d.decrementUsage()
 		}()
 	} else {
-		d.usageCount.Add(1)
+		d.usageCount++
 	}
 
 	return d, nil

--- a/downloader.go
+++ b/downloader.go
@@ -454,9 +454,14 @@ func (f *RequestedFile) getRepo() *Repo {
 	return config.Repos[f.repoName]
 }
 
-// key used for downloaders map; each active Downloader is referenced by its key
+// key used for downloaders map; each active Downloader is referenced by its
+// key. The destination path is part of the identity: the same upstream path
+// can be requested for different destinations at the same time (a client
+// filling the package cache while the prefetcher fetches the db into its
+// temporary directory), and such downloads must not share a Downloader
+// because only the creator's outputFileName receives the downloaded file.
 func (f *RequestedFile) key() string {
-	return f.repoName + f.urlPath()
+	return f.repoName + f.urlPath() + "->" + f.cachedFilePath
 }
 
 func (f *RequestedFile) urlPath() string {

--- a/downloader.go
+++ b/downloader.go
@@ -20,6 +20,14 @@ var (
 	downloadersMutex sync.Mutex
 )
 
+// downloadStallTimeout aborts a download whose upstream stops making
+// progress: connecting, returning the response headers and delivering each
+// next chunk of the body must all happen within this window. It bounds how
+// long clients can be stuck waiting on a wedged Downloader when
+// config.DownloadTimeout is unset (a variable only to allow shortening it
+// in tests).
+var downloadStallTimeout = time.Minute
+
 type Downloader struct {
 	key            string // repoName + path + filename
 	outputFileName string
@@ -95,15 +103,26 @@ func (d *Downloader) download() error {
 func (d *Downloader) downloadFromUpstream(repoURL string, proxyURL *url.URL) error {
 	upstreamURL := repoURL + d.urlPath
 
-	var req *http.Request
-	var err error
+	baseCtx := context.Background()
 	if config.DownloadTimeout > 0 {
-		ctx, ctxCancel := context.WithTimeout(context.Background(), time.Duration(config.DownloadTimeout)*time.Second)
-		defer ctxCancel()
-		req, err = http.NewRequestWithContext(ctx, http.MethodGet, upstreamURL, nil)
-	} else {
-		req, err = http.NewRequest(http.MethodGet, upstreamURL, nil)
+		var cancel context.CancelFunc
+		baseCtx, cancel = context.WithTimeout(baseCtx, time.Duration(config.DownloadTimeout)*time.Second)
+		defer cancel()
 	}
+
+	// The watchdog guards every phase of the transfer: connecting,
+	// receiving the response headers and receiving each next chunk of the
+	// body must all make progress within downloadStallTimeout, otherwise
+	// the request is cancelled. Without it a silently stalled upstream
+	// wedges this Downloader forever and every client of the file blocks
+	// in cond.Wait; config.DownloadTimeout alone does not help because it
+	// only caps the total duration and defaults to unlimited.
+	ctx, cancel := context.WithCancel(baseCtx)
+	defer cancel()
+	watchdog := time.AfterFunc(downloadStallTimeout, cancel)
+	defer watchdog.Stop()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, upstreamURL, nil)
 	if err != nil {
 		return err
 	}
@@ -134,6 +153,9 @@ func (d *Downloader) downloadFromUpstream(repoURL string, proxyURL *url.URL) err
 		return err
 	}
 	defer resp.Body.Close()
+
+	// Headers received: give the first body chunk its own full budget.
+	watchdog.Reset(downloadStallTimeout)
 
 	downloadedFilesCounter.WithLabelValues(d.repoName, req.Host, strconv.Itoa(resp.StatusCode)).Inc()
 
@@ -170,7 +192,9 @@ func (d *Downloader) downloadFromUpstream(repoURL string, proxyURL *url.URL) err
 	d.eventCond.Broadcast()
 	d.eventCond.L.Unlock()
 
-	if err := d.copyToBufferFile(resp.Body); err != nil {
+	if err := d.copyToBufferFile(resp.Body, func() {
+		watchdog.Reset(downloadStallTimeout)
+	}); err != nil {
 		return err
 	}
 
@@ -194,7 +218,10 @@ func (d *Downloader) downloadFromUpstream(repoURL string, proxyURL *url.URL) err
 	return nil
 }
 
-func (d *Downloader) copyToBufferFile(in io.ReadCloser) error {
+// copyToBufferFile streams the response body into the buffer file, calling
+// keepalive after every received chunk so the caller's stall watchdog knows
+// the transfer is making progress.
+func (d *Downloader) copyToBufferFile(in io.ReadCloser, keepalive func()) error {
 	out := d.bufferFile
 	buff := make([]byte, 1024*1024)
 
@@ -204,6 +231,8 @@ func (d *Downloader) copyToBufferFile(in io.ReadCloser) error {
 			if _, err2 := out.Write(buff[:n]); err2 != nil {
 				return err2
 			}
+			// progress means the chunk is both received and persisted
+			keepalive()
 
 			d.eventCond.L.Lock()
 			d.eventDataReceivedSize += n

--- a/downloader.go
+++ b/downloader.go
@@ -283,14 +283,20 @@ func (d *DownloadReader) Close() error {
 }
 
 func (d *DownloadReader) Read(p []byte) (int, error) {
-	d.downloader.eventCond.L.Lock()
-	for !(d.downloader.eventDataReceivedSize > d.offset || d.downloader.eventDone) {
-		d.downloader.eventCond.Wait()
+	// Snapshot the streaming state under the lock: the download goroutine
+	// keeps mutating eventDataReceivedSize (and eventually eventDone)
+	// concurrently, so they must not be re-read after unlocking.
+	dl := d.downloader
+	dl.eventCond.L.Lock()
+	for !(dl.eventDataReceivedSize > d.offset || dl.eventDone) {
+		dl.eventCond.Wait()
 	}
-	d.downloader.eventCond.L.Unlock()
+	received := dl.eventDataReceivedSize
+	done := dl.eventDone
+	dl.eventCond.L.Unlock()
 
-	if d.downloader.eventDataReceivedSize > d.offset {
-		n, err := d.downloader.bufferFile.ReadAt(p, int64(d.offset))
+	if received > d.offset {
+		n, err := dl.bufferFile.ReadAt(p, int64(d.offset))
 		d.offset += n
 		if err == io.EOF {
 			// EOF on the bufferFile does not mean that we are done downloading
@@ -298,7 +304,7 @@ func (d *DownloadReader) Read(p []byte) (int, error) {
 			err = nil
 		}
 		return n, err
-	} else if d.downloader.eventDone {
+	} else if done {
 		return 0, io.EOF
 	}
 

--- a/downloader.go
+++ b/downloader.go
@@ -35,7 +35,7 @@ type Downloader struct {
 
 	// downloaded metadata
 	modificationTime time.Time
-	contentLength    int
+	contentLength    int64
 
 	repoName string
 	repo     *Repo
@@ -54,7 +54,7 @@ type Downloader struct {
 	eventMetadataReceived bool
 	eventNotModified      bool
 	eventDone             bool
-	eventDataReceivedSize int
+	eventDataReceivedSize int64
 }
 
 func (d *Downloader) decrementUsage() {
@@ -182,7 +182,7 @@ func (d *Downloader) downloadFromUpstream(repoURL string, proxyURL *url.URL) err
 	}
 
 	if clStr := resp.Header.Get("Content-Length"); clStr != "" {
-		if cl, err := strconv.Atoi(clStr); err == nil {
+		if cl, err := strconv.ParseInt(clStr, 10, 64); err == nil {
 			d.contentLength = cl
 		}
 	}
@@ -235,7 +235,7 @@ func (d *Downloader) copyToBufferFile(in io.ReadCloser, keepalive func()) error 
 			keepalive()
 
 			d.eventCond.L.Lock()
-			d.eventDataReceivedSize += n
+			d.eventDataReceivedSize += int64(n)
 			d.eventCond.Broadcast()
 			d.eventCond.L.Unlock()
 		}
@@ -303,7 +303,7 @@ func getDownloadReader(f *RequestedFile) (time.Time, io.ReadSeekCloser, error) {
 
 type DownloadReader struct {
 	downloader *Downloader
-	offset     int
+	offset     int64
 }
 
 func (d *DownloadReader) Close() error {
@@ -325,8 +325,8 @@ func (d *DownloadReader) Read(p []byte) (int, error) {
 	dl.eventCond.L.Unlock()
 
 	if received > d.offset {
-		n, err := dl.bufferFile.ReadAt(p, int64(d.offset))
-		d.offset += n
+		n, err := dl.bufferFile.ReadAt(p, d.offset)
+		d.offset += int64(n)
 		if err == io.EOF {
 			// EOF on the bufferFile does not mean that we are done downloading
 			// EOF must be sent only once the download is complete
@@ -343,9 +343,9 @@ func (d *DownloadReader) Read(p []byte) (int, error) {
 func (d *DownloadReader) Seek(offset int64, whence int) (int64, error) {
 	switch whence {
 	case io.SeekStart:
-		d.offset = int(offset)
+		d.offset = offset
 	case io.SeekCurrent:
-		d.offset += int(offset)
+		d.offset += offset
 	case io.SeekEnd:
 		// note that we can call Seek method only after the metadata is received
 		d.offset = d.downloader.contentLength
@@ -353,7 +353,7 @@ func (d *DownloadReader) Seek(offset int64, whence int) (int64, error) {
 		return 0, fmt.Errorf("unknown whence parameter: %v", whence)
 	}
 
-	return int64(d.offset), nil
+	return d.offset, nil
 }
 
 // getDownloader returns a downloader that represents currently (and asynchronously) downloaded file

--- a/downloader_test.go
+++ b/downloader_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -412,6 +413,55 @@ func TestStallWatchdogResetsBetweenPhases(t *testing.T) {
 	require.Equal(t, content, w.Body.String(),
 		"a download making per-phase progress must complete in full")
 }
+
+// TestPrefetchAndClientDoNotShareDownloader is a regression test for a
+// Downloader key collision: the key did not include the destination path, so
+// a prefetch downloading a db into its temporary directory and a client
+// downloading the same db into the package cache shared one Downloader --
+// and only the creator's destination received the file.
+func TestPrefetchAndClientDoNotShareDownloader(t *testing.T) {
+	content := "db content for key collision test"
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", strconv.Itoa(len(content)))
+		w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+		time.Sleep(300 * time.Millisecond) // keep the download in flight
+		_, _ = w.Write([]byte(content))
+	}
+	mirror := httptest.NewServer(http.HandlerFunc(handler))
+	defer mirror.Close()
+
+	cacheDir := t.TempDir()
+	tmpDBDir := t.TempDir()
+
+	config = &Config{
+		CacheDir:        cacheDir,
+		Port:            -1,
+		DownloadTimeout: 10,
+		Repos:           map[string]*Repo{"collide-repo": {URL: mirror.URL}},
+	}
+
+	clientDone := make(chan error, 1)
+	go func() {
+		req := httptest.NewRequest(http.MethodGet, "/repo/collide-repo/core.db", nil)
+		w := httptest.NewRecorder()
+		clientDone <- handleRequest(w, req)
+	}()
+
+	// let the client create its Downloader first, then prefetch the same
+	// upstream path into a different destination while it is in flight
+	time.Sleep(50 * time.Millisecond)
+	require.NoError(t, prefetchRequest("/repo/collide-repo/core.db", tmpDBDir))
+	require.NoError(t, <-clientDone)
+
+	clientFile, err := os.ReadFile(filepath.Join(cacheDir, "pkgs", "collide-repo", "core.db"))
+	require.NoError(t, err, "client destination must receive the file")
+	require.Equal(t, content, string(clientFile))
+
+	prefetchFile, err := os.ReadFile(filepath.Join(tmpDBDir, "core.db"))
+	require.NoError(t, err, "prefetch destination must receive the file")
+	require.Equal(t, content, string(prefetchFile))
+}
+
 func TestParseRequestURLInvalid(t *testing.T) {
 	config = &Config{}
 	_, err := parseRequestURL("/invalid/path")
@@ -431,9 +481,9 @@ func TestRequestedFile(t *testing.T) {
 	data := []struct {
 		input, urlPath, key string
 	}{
-		{"/repo/noPath/foobar-3.3.6-7-x86_64.pkg.tar.zst", "/foobar-3.3.6-7-x86_64.pkg.tar.zst", "noPath/foobar-3.3.6-7-x86_64.pkg.tar.zst"},
-		{"/repo/extended/path/bar-222.pkg.tar.zst", "/path/bar-222.pkg.tar.zst", "extended/path/bar-222.pkg.tar.zst"},
-		{"/repo/upstream/extra/os/x86_64/linux-5.19.pkg.tar.zst", "/extra/os/x86_64/linux-5.19.pkg.tar.zst", "upstream/extra/os/x86_64/linux-5.19.pkg.tar.zst"},
+		{"/repo/noPath/foobar-3.3.6-7-x86_64.pkg.tar.zst", "/foobar-3.3.6-7-x86_64.pkg.tar.zst", "noPath/foobar-3.3.6-7-x86_64.pkg.tar.zst->pkgs/noPath/foobar-3.3.6-7-x86_64.pkg.tar.zst"},
+		{"/repo/extended/path/bar-222.pkg.tar.zst", "/path/bar-222.pkg.tar.zst", "extended/path/bar-222.pkg.tar.zst->pkgs/extended/bar-222.pkg.tar.zst"},
+		{"/repo/upstream/extra/os/x86_64/linux-5.19.pkg.tar.zst", "/extra/os/x86_64/linux-5.19.pkg.tar.zst", "upstream/extra/os/x86_64/linux-5.19.pkg.tar.zst->pkgs/upstream/linux-5.19.pkg.tar.zst"},
 	}
 
 	for _, d := range data {

--- a/downloader_test.go
+++ b/downloader_test.go
@@ -10,7 +10,9 @@ import (
 	"net/http/httptest"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -177,6 +179,122 @@ func TestDownloadNotModified(t *testing.T) {
 	require.NoError(t, err)
 	// Should serve from cache (304 means use cached version)
 	require.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestConcurrentForceCheckRequests is a regression test for a race in the
+// Downloader lifecycle: releasing the last reference used to decide on
+// cleanup outside downloadersMutex, so a client attaching to the Downloader
+// at that moment could read from an already-closed buffer file, and a stale
+// cleanup could delete the map entry and buffer file of a freshly created
+// Downloader for the same key.
+//
+// Files that force an upstream check (.db) create a short-lived Downloader
+// on every request even when cached, so hammering one such path from many
+// goroutines exercises the attach/release window continuously.
+func TestConcurrentForceCheckRequests(t *testing.T) {
+	content := "pacoloco test db content"
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+		w.Header().Set("Content-Length", strconv.Itoa(len(content)))
+		_, _ = w.Write([]byte(content))
+	}
+	mirror := httptest.NewServer(http.HandlerFunc(handler))
+	defer mirror.Close()
+
+	config = &Config{
+		CacheDir:        t.TempDir(),
+		Port:            -1,
+		DownloadTimeout: 10,
+		Repos:           map[string]*Repo{"race-repo": {URL: mirror.URL}},
+	}
+
+	const (
+		clients           = 32
+		requestsPerClient = 64
+	)
+
+	errCh := make(chan error, clients)
+	var wg sync.WaitGroup
+	for range clients {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range requestsPerClient {
+				req := httptest.NewRequest(http.MethodGet, "/repo/race-repo/test.db", nil)
+				w := httptest.NewRecorder()
+				if err := handleRequest(w, req); err != nil {
+					errCh <- fmt.Errorf("handleRequest: %w", err)
+					return
+				}
+				if body := w.Body.String(); body != content {
+					errCh <- fmt.Errorf("got body %q, want %q", body, content)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+}
+
+// TestConcurrentDownloadsShareUpstreamRequest verifies the single-flight
+// behavior: concurrent clients of one uncached file must share a single
+// upstream download and each receive the complete content.
+func TestConcurrentDownloadsShareUpstreamRequest(t *testing.T) {
+	content := strings.Repeat("pacoloco", 128*1024) // 1 MiB
+
+	var upstreamHits atomic.Int32
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits.Add(1)
+		w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+		w.Header().Set("Content-Length", strconv.Itoa(len(content)))
+		// Trickle the body so every client attaches while the download
+		// is still in flight.
+		half := len(content) / 2
+		_, _ = w.Write([]byte(content[:half]))
+		w.(http.Flusher).Flush()
+		time.Sleep(300 * time.Millisecond)
+		_, _ = w.Write([]byte(content[half:]))
+	}
+	mirror := httptest.NewServer(http.HandlerFunc(handler))
+	defer mirror.Close()
+
+	config = &Config{
+		CacheDir:        t.TempDir(),
+		Port:            -1,
+		DownloadTimeout: 10,
+		Repos:           map[string]*Repo{"flight-repo": {URL: mirror.URL}},
+	}
+
+	const clients = 16
+
+	errCh := make(chan error, clients)
+	var wg sync.WaitGroup
+	for range clients {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := httptest.NewRequest(http.MethodGet, "/repo/flight-repo/pkg-1-1-any.pkg.tar.zst", nil)
+			w := httptest.NewRecorder()
+			if err := handleRequest(w, req); err != nil {
+				errCh <- fmt.Errorf("handleRequest: %w", err)
+				return
+			}
+			if body := w.Body.String(); body != content {
+				errCh <- fmt.Errorf("got %d bytes, want %d", len(body), len(content))
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+	require.Equal(t, int32(1), upstreamHits.Load(),
+		"concurrent clients must share one upstream download")
 }
 
 func TestParseRequestURLInvalid(t *testing.T) {

--- a/downloader_test.go
+++ b/downloader_test.go
@@ -475,6 +475,26 @@ func TestParseRequestURLInvalid(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestDownloadSizesUse64Bits pins the >2 GiB size arithmetic that used to
+// break on 32-bit platforms (linux/arm): sizes and offsets were plain int,
+// so a large package overflowed the reader offset and its Content-Length
+// did not survive parsing. The assertions are trivially true on 64-bit
+// builds; the 32-bit CI test legs are where they bite -- with the old int
+// fields this test does not even compile there (constant overflow).
+func TestDownloadSizesUse64Bits(t *testing.T) {
+	const huge = int64(3) << 30 // 3 GiB, above MaxInt32
+
+	d := &DownloadReader{downloader: &Downloader{contentLength: huge}}
+
+	pos, err := d.Seek(0, io.SeekEnd)
+	require.NoError(t, err)
+	require.Equal(t, huge, pos)
+
+	pos, err = d.Seek(huge+1, io.SeekStart)
+	require.NoError(t, err)
+	require.Equal(t, huge+1, pos)
+}
+
 func TestRequestedFile(t *testing.T) {
 	config = &Config{}
 

--- a/downloader_test.go
+++ b/downloader_test.go
@@ -297,6 +297,121 @@ func TestConcurrentDownloadsShareUpstreamRequest(t *testing.T) {
 		"concurrent clients must share one upstream download")
 }
 
+// TestStalledDownloadAborts is a regression test for a permanent hang: with
+// download_timeout unset there was no bound on a silently stalled upstream,
+// so the download goroutine blocked forever, the Downloader stayed in the
+// downloaders map and every future client of the same file hung in
+// cond.Wait. The stall watchdog must abort such transfers: before the
+// upstream headers arrive the client gets an error, after them the abort
+// surfaces as a truncated body -- but in both cases the request finishes
+// and the Downloader is cleaned up.
+func TestStalledDownloadAborts(t *testing.T) {
+	content := "stalled content that never fully arrives"
+
+	newStallServer := func(t *testing.T, sendPrefix int) *httptest.Server {
+		release := make(chan struct{})
+		handler := func(w http.ResponseWriter, r *http.Request) {
+			if sendPrefix > 0 {
+				w.Header().Set("Content-Length", strconv.Itoa(len(content)))
+				_, _ = w.Write([]byte(content[:sendPrefix]))
+				w.(http.Flusher).Flush()
+			}
+			<-release // stall forever
+		}
+		mirror := httptest.NewServer(http.HandlerFunc(handler))
+		t.Cleanup(mirror.Close)
+		t.Cleanup(func() { close(release) }) // LIFO: runs before mirror.Close
+		return mirror
+	}
+
+	oldStall := downloadStallTimeout
+	downloadStallTimeout = 200 * time.Millisecond
+	defer func() { downloadStallTimeout = oldStall }()
+
+	run := func(t *testing.T, mirror *httptest.Server, fileName string) (*httptest.ResponseRecorder, error) {
+		config = &Config{
+			CacheDir:        t.TempDir(),
+			Port:            -1,
+			DownloadTimeout: 0, // the dangerous default: no total timeout
+			Repos:           map[string]*Repo{"stall-repo": {URL: mirror.URL}},
+		}
+
+		w := httptest.NewRecorder()
+		done := make(chan error, 1)
+		go func() {
+			req := httptest.NewRequest(http.MethodGet, "/repo/stall-repo/"+fileName, nil)
+			done <- handleRequest(w, req)
+		}()
+
+		select {
+		case err := <-done:
+			return w, err
+		case <-time.After(10 * time.Second):
+			t.Fatal("request against a stalled upstream hung instead of aborting")
+			return nil, nil
+		}
+	}
+
+	requireDownloadersCleaned := func(t *testing.T) {
+		require.Eventually(t, func() bool {
+			downloadersMutex.Lock()
+			defer downloadersMutex.Unlock()
+			return len(downloaders) == 0
+		}, time.Second, 10*time.Millisecond, "aborted Downloader must be removed from the map")
+	}
+
+	t.Run("stall before headers", func(t *testing.T) {
+		_, err := run(t, newStallServer(t, 0), "stalled-1-1-any.pkg.tar.zst")
+		require.Error(t, err, "a download stalled before headers must fail")
+		requireDownloadersCleaned(t)
+	})
+
+	t.Run("stall mid-body", func(t *testing.T) {
+		w, err := run(t, newStallServer(t, 8), "midbody-1-1-any.pkg.tar.zst")
+		// The response headers were already relayed, so the abort cannot
+		// become an HTTP error anymore; it must surface as truncation.
+		require.NoError(t, err)
+		require.Less(t, w.Body.Len(), len(content), "stalled body must be truncated, not complete")
+		requireDownloadersCleaned(t)
+	})
+}
+
+// TestStallWatchdogResetsBetweenPhases pins the per-phase semantics of the
+// stall watchdog: connecting/receiving headers and receiving the first body
+// chunk are separate phases, each with its own downloadStallTimeout budget.
+// Without the reset after the headers arrive, a server that spends most of
+// the budget before the headers and then delivers the body promptly was
+// aborted even though no single phase stalled.
+func TestStallWatchdogResetsBetweenPhases(t *testing.T) {
+	content := "slow but steady wins the race"
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(350 * time.Millisecond) // headers arrive late but in time
+		w.Header().Set("Content-Length", strconv.Itoa(len(content)))
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		time.Sleep(350 * time.Millisecond) // body arrives late but in time
+		_, _ = w.Write([]byte(content))
+	}
+	mirror := httptest.NewServer(http.HandlerFunc(handler))
+	defer mirror.Close()
+
+	oldStall := downloadStallTimeout
+	downloadStallTimeout = 500 * time.Millisecond
+	defer func() { downloadStallTimeout = oldStall }()
+
+	config = &Config{
+		CacheDir:        t.TempDir(),
+		Port:            -1,
+		DownloadTimeout: 0,
+		Repos:           map[string]*Repo{"steady-repo": {URL: mirror.URL}},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/repo/steady-repo/steady-1-1-any.pkg.tar.zst", nil)
+	w := httptest.NewRecorder()
+	require.NoError(t, handleRequest(w, req))
+	require.Equal(t, content, w.Body.String(),
+		"a download making per-phase progress must complete in full")
+}
 func TestParseRequestURLInvalid(t *testing.T) {
 	config = &Config{}
 	_, err := parseRequestURL("/invalid/path")

--- a/integration_test.go
+++ b/integration_test.go
@@ -144,13 +144,15 @@ func testRequestExistingRepo(t *testing.T) {
 	expectedRequests := testutil.ToFloat64(requestCounter) + 1
 	expectedServed := testutil.ToFloat64(servedCounter)
 	expectedMissed := testutil.ToFloat64(missedCounter)
-	expectedErrorServed := testutil.ToFloat64(cacheErrorCounter) + 1 // expected since we 404
+	expectedErrorServed := testutil.ToFloat64(cacheErrorCounter) + 1 // the download fails
 
 	req := httptest.NewRequest("GET", pacolocoURL+"/repo/repo1/test.db", nil)
 	w := httptest.NewRecorder()
 	pacolocoHandler(w, req)
 	resp := w.Result()
-	require.Equal(t, resp.StatusCode, 404)
+	// the repo exists but its upstream is unreachable: that is a server-side
+	// failure (500), not a missing file (404)
+	require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
 
 	actualRequests := testutil.ToFloat64(requestCounter)
 	actualServed := testutil.ToFloat64(servedCounter)

--- a/pacoloco.go
+++ b/pacoloco.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -86,10 +87,20 @@ func main() {
 	http.HandleFunc("/repo/", pacolocoHandler)
 	// Expose prometheus metrics
 	http.Handle("/metrics", promhttp.Handler())
+	// ReadHeaderTimeout protects against clients that open a connection and
+	// never send a request (slowloris); IdleTimeout reclaims parked
+	// keep-alive connections. Deliberately no ReadTimeout/WriteTimeout:
+	// serving a large package to a slow client is a legitimate long-running
+	// response.
+	server := &http.Server{
+		Addr:              listenAddr,
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       2 * time.Minute,
+	}
 	if config.Tls != nil {
-		err = http.ListenAndServeTLS(listenAddr, config.Tls.Certificate, config.Tls.Key, nil)
+		err = server.ListenAndServeTLS(config.Tls.Certificate, config.Tls.Key)
 	} else {
-		err = http.ListenAndServe(listenAddr, nil)
+		err = server.ListenAndServe()
 	}
 	if err != nil {
 		log.Fatal(err)

--- a/pacoloco.go
+++ b/pacoloco.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -116,10 +117,20 @@ func gatherCacheStats(repoDir string) (totalCacheSize float64, totalPackageCount
 	return float64(size), float64(numberOfPackages), err
 }
 
+// errNotFound marks request errors that must surface as 404: malformed
+// request paths and repos missing from the config. Everything else (upstream
+// failures, disk errors) is a server-side problem and must not masquerade as
+// "no such file", both for pacman and for whoever reads the logs.
+var errNotFound = errors.New("not found")
+
 func pacolocoHandler(w http.ResponseWriter, req *http.Request) {
 	if err := handleRequest(w, req); err != nil {
 		log.Println(err)
-		w.WriteHeader(http.StatusNotFound)
+		if errors.Is(err, errNotFound) {
+			w.WriteHeader(http.StatusNotFound)
+		} else {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
 	}
 }
 
@@ -196,11 +207,11 @@ func prefetchRequest(urlPath string, cachePath string) error {
 func handleRequest(w http.ResponseWriter, req *http.Request) error {
 	f, err := parseRequestURL(req.URL.Path)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w: %v", errNotFound, err)
 	}
 
 	if f.getRepo() == nil {
-		return fmt.Errorf("cannot find repo %s in the config file", f.repoName)
+		return fmt.Errorf("%w: cannot find repo %s in the config file", errNotFound, f.repoName)
 	}
 
 	cacheRequestsCounter.WithLabelValues(f.repoName).Inc()
@@ -222,8 +233,10 @@ func handleRequest(w http.ResponseWriter, req *http.Request) error {
 	} else {
 		http.ServeContent(w, req, f.fileName, modTime, r)
 		cacheMissedCounter.WithLabelValues(f.repoName).Inc()
+		// ServeContent has already written the response; returning an
+		// error here would only produce a superfluous WriteHeader call.
 		if err := r.Close(); err != nil {
-			return err
+			log.Printf("error closing download reader for %v: %v", f.key(), err)
 		}
 	}
 

--- a/pacoloco_test.go
+++ b/pacoloco_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"io"
 	"log"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
@@ -16,6 +18,40 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(m.Run())
+}
+
+// TestHandlerStatusCodes verifies that only genuinely missing resources are
+// reported as 404: upstream and internal failures used to be masked as 404
+// too, which made every production incident look like a missing file.
+func TestHandlerStatusCodes(t *testing.T) {
+	mirror := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer mirror.Close()
+
+	config = &Config{
+		CacheDir:        t.TempDir(),
+		Port:            -1,
+		DownloadTimeout: 10,
+		Repos:           map[string]*Repo{"good-repo": {URL: mirror.URL}},
+	}
+
+	cases := []struct {
+		name string
+		url  string
+		want int
+	}{
+		{"malformed path", "/repo/", http.StatusNotFound},
+		{"unknown repo", "/repo/nope/test-1-1-any.pkg.tar.zst", http.StatusNotFound},
+		{"upstream failure", "/repo/good-repo/test-1-1-any.pkg.tar.zst", http.StatusInternalServerError},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			pacolocoHandler(w, httptest.NewRequest(http.MethodGet, tc.url, nil))
+			require.Equal(t, tc.want, w.Code)
+		})
+	}
 }
 
 func TestPathMatcher(t *testing.T) {

--- a/prefetch_test.go
+++ b/prefetch_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"sync"
 	"testing"
 	"time"
 
@@ -41,6 +42,32 @@ repos:
 		t.Fatalf("parseConfig failed: %v", err)
 	}
 	return tmpDir
+}
+
+// TestConcurrentDBUpdatesNotLost exercises parallel client requests updating
+// the prefetch db, as happens when several machines upgrade at once. Without
+// a sqlite busy timeout concurrent writers fail immediately with "database
+// is locked" and their updates are silently dropped (updateDBRequestedFile
+// only logs db errors).
+func TestConcurrentDBUpdatesNotLost(t *testing.T) {
+	testSetupHelper(t)
+	setupPrefetch()
+
+	const writers = 40
+
+	var wg sync.WaitGroup
+	for i := range writers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			updateDBRequestedFile("example", fmt.Sprintf("pkg%d-1.0-1-x86_64.pkg.tar.zst", i))
+		}()
+	}
+	wg.Wait()
+
+	var count int64
+	require.NoError(t, prefetchDB.Model(&Package{}).Count(&count).Error)
+	require.EqualValues(t, writers, count, "concurrent db updates must not be lost")
 }
 
 func TestSetupPrefetch(t *testing.T) {

--- a/purge.go
+++ b/purge.go
@@ -53,7 +53,11 @@ func purgeStaleFiles(cacheDir string, purgeFilesAfter int, repoName string) {
 		}
 		t := times.Get(info)
 		atime := t.AccessTime()
-		if atime.Before(removeIfOlder) {
+		// A file is stale only if it is neither read nor written: the
+		// buffer file of an in-flight download has no readers (stale
+		// atime) but is actively appended to (fresh mtime), and must not
+		// be deleted from under its Downloader.
+		if atime.Before(removeIfOlder) && info.ModTime().Before(removeIfOlder) {
 			log.Printf("Remove stale file %v as its access time (%v) is too old", path, atime)
 			if err := os.Remove(path); err != nil {
 				log.Print(err)

--- a/purge_test.go
+++ b/purge_test.go
@@ -51,6 +51,28 @@ func TestPurgeWithSubdirectories(t *testing.T) {
 	require.ErrorIs(t, err, os.ErrNotExist, "nested file should be removed")
 }
 
+// TestPurgeSparesActivelyWrittenFiles ensures the purge routine does not
+// delete a file that is still being written: the buffer file of an
+// in-flight download has no readers (stale atime) but a fresh mtime, and
+// removing it would break the download streaming from it.
+func TestPurgeSparesActivelyWrittenFiles(t *testing.T) {
+	purgeFilesAfter := 3600 * 24 * 30
+	dir := t.TempDir()
+	repoDir := path.Join(dir, "pkgs", "inflightrepo")
+	require.NoError(t, os.MkdirAll(repoDir, os.ModePerm))
+
+	buffer := path.Join(repoDir, ".pkg-1-1-any.pkg.tar.zst")
+	require.NoError(t, os.WriteFile(buffer, []byte("partial download"), os.ModePerm))
+	threshold := time.Now().Add(time.Duration(-purgeFilesAfter) * time.Second)
+	// stale atime (nobody reads a buffer file), fresh mtime (writer active)
+	require.NoError(t, os.Chtimes(buffer, threshold.Add(-time.Hour), time.Now()))
+
+	purgeStaleFiles(dir, purgeFilesAfter, "inflightrepo")
+
+	_, err := os.Stat(buffer)
+	require.NoError(t, err, "actively written file must survive the purge")
+}
+
 func TestPurge(t *testing.T) {
 	purgeFilesAfter := 3600 * 24 * 30 // purge files if they are not accessed for 30 days
 

--- a/urls.go
+++ b/urls.go
@@ -46,14 +46,13 @@ func parseMirrorlistURLs(file *os.File) ([]string, error) {
 func (r *Repo) getMirrorlistURLs() ([]string, error) {
 	const MirrorlistCheckInterval = 5 * time.Second
 
-	if time.Since(r.LastMirrorlistCheck) < MirrorlistCheckInterval {
-		return r.URLs, nil
-	}
-
+	// The freshness check must happen under the same lock as the refresh:
+	// an unlocked read of LastMirrorlistCheck and URLs races with a
+	// concurrent refresh rewriting them (torn slice header). The critical
+	// section is cheap, so every caller simply takes the mutex.
 	r.MirrorlistMutex.Lock()
 	defer r.MirrorlistMutex.Unlock()
 
-	// Test time again in case another routine already checked in the meantime
 	if time.Since(r.LastMirrorlistCheck) < MirrorlistCheckInterval {
 		return r.URLs, nil
 	}

--- a/urls_test.go
+++ b/urls_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path"
+	"sync"
 	"testing"
 	"time"
 
@@ -113,6 +114,32 @@ repos:
 
 	gotCheckTime := archTest.LastMirrorlistCheck
 	require.LessOrEqual(t, time.Since(gotCheckTime), 3*time.Second)
+}
+
+// TestGetMirrorlistURLsConcurrent is a regression test for a data race:
+// the freshness fast path read LastMirrorlistCheck and returned r.URLs
+// without holding MirrorlistMutex, racing with a concurrent refresh that
+// writes both fields under the lock. Run with -race.
+func TestGetMirrorlistURLsConcurrent(t *testing.T) {
+	temp := t.TempDir()
+	tmpMirrorfile := path.Join(temp, "tmpMirrorFile")
+	require.NoError(t, os.WriteFile(tmpMirrorfile, []byte(mirrorlist), 0o644))
+
+	repo := &Repo{Mirrorlist: tmpMirrorfile}
+
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 100 {
+				repo.getUrls()
+			}
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, expectedURLs, repo.getUrls())
 }
 
 func TestEmptyMirrorlist(t *testing.T) {


### PR DESCRIPTION
## Motivation

I run pacoloco as a shared cache for four Arch machines with
`ParallelDownloads` enabled. When several of them run `pacman -Syu` at
the same time (systemd timers firing in the same minute), clients would
sporadically fail with what looked like 404s or truncated downloads for
files that clearly exist upstream — and occasionally a single file
would get permanently stuck until the service was restarted.

Chasing those incidents led me into the concurrency paths of
`downloader.go`. The direct culprit turned out to be a lifecycle race
in the shared `Downloader`, and while writing a reproducer for it I
audited the neighbouring code for the same class of problems and fixed
what I found. Every fix is a separate commit, and every bug commit
carries a regression test that fails on the code before it (test-first;
verified with `-race` where relevant).

## The fixes (one commit each)

### Races and hangs — the production incidents

1. **`fix: guard Downloader usage count with downloadersMutex`**
   Releasing the last reference decided "I clean up" from an atomic
   counter read *outside* `downloadersMutex`, racing with
   `getDownloader` attaching a new client. The client could end up
   streaming from a closed, deleted buffer file, and the stale cleanup
   could even delete the map entry of a *newer* Downloader for the same
   key, letting two downloads write into one buffer file. `.db` files
   (`forceCheckAtServer`) create a short-lived Downloader on every
   request even when cached, so a fleet refreshing the same `core.db`
   simultaneously hits this window all the time.
   Repro: `TestConcurrentForceCheckRequests` fails reliably before the fix.

2. **`fix: snapshot streaming state in DownloadReader.Read under the lock`**
   `eventDataReceivedSize`/`eventDone` are mutated under `eventCond.L`
   but were re-read after unlock — a data race.
   Repro: `go test -race -run TestConcurrentDownloadsShareUpstreamRequest -count=30`.

3. **`fix: take MirrorlistMutex for the mirrorlist freshness fast path`**
   The unlocked freshness check returned `r.URLs` (a slice header)
   while a concurrent refresh rewrites it under the mutex; fires on the
   first concurrent burst to a mirrorlist-backed repo.
   Repro: `go test -race -run TestGetMirrorlistURLsConcurrent`.

4. **`fix: abort downloads whose upstream stops making progress`**
   With `download_timeout` unset there is no bound at all: an upstream
   that goes silent keeps the download goroutine blocked forever, the
   Downloader stays in the map, and every future client of that file
   hangs in `cond.Wait` until restart. A stall watchdog now requires
   progress per phase (connect/headers/each body chunk, 1 minute each)
   and cancels the request otherwise; waiting clients get an error (or
   a truncated body when headers were already relayed) and the next
   request starts fresh. `download_timeout` keeps its meaning as the
   total cap.
   Repro: `TestStalledDownloadAborts`, `TestStallWatchdogResetsBetweenPhases`.

5. **`fix: include the destination path in the Downloader single-flight key`**
   The prefetcher downloads db files into a temporary directory, but
   the single-flight key ignored the destination: a client downloading
   the same upstream path shared the prefetcher's Downloader and only
   the creator's destination received the file. Client-to-client
   single-flight is preserved and now pinned by a test asserting that N
   concurrent clients produce exactly one upstream request.
   Repro: `TestPrefetchAndClientDoNotShareDownloader`.

### Hardening found during the same audit

6. **`fix: stop masking server-side failures as 404`** — every error
   became 404, so upstream outages and disk problems looked like
   missing files both to pacman and in the logs (this is exactly why my
   incidents were hard to diagnose). 404 is now reserved for malformed
   paths and unknown repos; everything else answers 500.

7. **`fix: do not purge files that are still being written`** — purge
   judged staleness by atime alone; in-flight buffer files have no
   readers, so a download running longer than `purge_files_after`
   could lose its buffer mid-transfer. A file must now be stale on
   both atime and mtime.

8. **`fix: use int64 for download sizes and offsets`** — sizes were
   plain `int`, which is 32-bit on linux/arm: packages over 2 GiB
   overflow the reader offset and their Content-Length doesn't survive
   `strconv.Atoi`. The regression test doesn't even compile with the
   old types on a 32-bit build.

9. **`fix: set read-header and idle timeouts on the HTTP server`** —
   slowloris/idle-connection hygiene. Deliberately no
   ReadTimeout/WriteTimeout: serving a large package to a slow client
   is a legitimate long-running response.

10. **`test: pin that concurrent prefetch-db updates are not lost`** —
    an honest false positive: I suspected "database is locked" drops
    under parallel client load, but mattn/go-sqlite3 already defaults
    `busy_timeout` to 5000 ms, and a 40-writer stress run loses
    nothing. The test stays to pin that property against future
    driver/DSN changes, since `updateDBRequestedFile` only logs db
    errors and a regression would be silent.

11. **`fix: drop unsupported semver cooldown options from dependabot config`** —
    unrelated to the download path, but urgent: Dependabot rejects the
    whole config file over `semver-major-days` on the github-actions and
    docker ecosystems (it is only supported for semver ecosystems like
    gomod), which silently disables all dependency updates. Shipping it
    here since the broken config landed with the recently merged CI PR.

## Behaviour changes to be aware of

- Upstream failures answer **500** instead of 404. After all mirrors
  are exhausted this includes a genuine upstream 404 — distinguishing
  that case would need plumbing status codes through the mirror retry
  loop; I can do that here or as a follow-up if you'd prefer 404 there.
- Purge now keeps files whose **mtime** is fresh even if atime is old.
- Transfers making zero progress abort after ~1 minute per phase
  (previously: hung forever when `download_timeout` was unset).

## Validation

gofmt -l .          # clean
go vet ./...        # clean
go test -count=5 ./...
go test -race -count=3 ./...
go test -race -run 'TestParallelDownload|TestConcurrentDownloadsShareUpstreamRequest|TestStalledDownloadAborts|TestPrefetchAndClientDoNotShareDownloader|TestGetMirrorlistURLsConcurrent' -count=10 ./...
GOOS=linux GOARCH=arm GOARM=7 go build ./...
GOOS=linux GOARCH=arm64 go build ./...
GOOS=linux GOARCH=386 go build ./...

Each bug commit was developed red-first: the test was written and shown
to fail (or race) against the previous commit, then the fix turned it
green. Happy to split this into smaller PRs if you prefer reviewing the
races separately from the hardening.