### PR TITLE
ci: cut a release on every master merge

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -328,6 +328,9 @@ jobs:
     if: github.event_name == 'push'
     needs:
       - build
+    # Digest of the published manifest list, reused by the release job.
+    outputs:
+      digest: ${{ steps.image.outputs.digest }}
     permissions:
       contents: read
       # Required to push the manifest list and provenance to GHCR.
@@ -407,3 +410,67 @@ jobs:
           subject-name: ${{ env.IMAGE_REF }}
           subject-digest: ${{ steps.image.outputs.digest }}
           push-to-registry: true
+
+  # Every master merge that published images becomes a release: bump the
+  # latest X.Y tag, point the new version tag at the manifest list that
+  # merge_and_publish just pushed (same digest, so its provenance still
+  # applies), then create the GitHub release. The tag is created with the
+  # workflow's own GITHUB_TOKEN, so it does not retrigger this workflow;
+  # manually pushed tags still take the tag leg above and skip this job.
+  release:
+    name: create release
+    runs-on: *runner-amd64
+    timeout-minutes: 10
+    # Only master matches the push branches filter, so ref_type is enough.
+    if: github.event_name == 'push' && github.ref_type == 'branch'
+    needs:
+      - merge_and_publish
+    permissions:
+      # Required to create the version tag and its GitHub release.
+      contents: write
+      # Required to add the version tag to the manifest list on GHCR.
+      packages: write
+    env:
+      DIGEST: ${{ needs.merge_and_publish.outputs.digest }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      # Spec requires ref to be lowercase, but user/org/repo names may have
+      # mixed case.
+      - name: Sanitize image ref
+        run: echo "IMAGE_REF=${REGISTRY}/${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
+      - name: Compute next version
+        run: |
+          latest=$(gh api "repos/${GITHUB_REPOSITORY}/tags" --paginate \
+            --jq '.[].name' | { grep -xE '[0-9]+\.[0-9]+' || true; } \
+            | sort -V | tail -n1)
+          if [[ -n "$latest" ]]; then
+            next="${latest%.*}.$(( ${latest##*.} + 1 ))"
+          else
+            # No X.Y tag yet (e.g. a fresh fork): start the scheme at 1.0.
+            next="1.0"
+          fi
+          echo "NEXT=${next}" >> "$GITHUB_ENV"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.1.0
+
+      - name: Login to Container Registry
+        uses: docker/login-action@v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Retagging runs before the release is created: a cancelled run leaves
+      # at worst an image tag the next run overwrites, never a released
+      # version without an image.
+      - name: Tag image with version
+        run: >-
+          docker buildx imagetools create -t "${IMAGE_REF}:${NEXT}"
+          "${IMAGE_REF}@${DIGEST}"
+
+      - name: Create release
+        run: >-
+          gh release create "$NEXT" --repo "$GITHUB_REPOSITORY"
+          --target "$GITHUB_SHA" --generate-notes

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,53 @@
+# Releasing
+
+Releases are fully automatic. There is nothing to configure and no manual
+steps: no personal access tokens, no secrets, no repository settings. The
+whole process lives in the `release` job of
+[`.github/workflows/push.yaml`](../.github/workflows/push.yaml).
+
+## How it works
+
+Every merge to `master` that touches Go code, `go.mod`/`go.sum`, the
+`Dockerfile`, or the workflow itself runs the CI pipeline. Once tests pass
+and the multi-arch image is published, the `release` job:
+
+1. Takes the latest `X.Y` tag and bumps it by one: `1.8` → `1.9` → `1.10`.
+   No `v` prefix, matching the existing tag scheme.
+2. Adds the new version tag to the already-published container image on
+   GHCR. The image is not rebuilt — the version tag points at the same
+   digest as `latest`, so its build provenance attestation still applies.
+3. Creates the git tag and a GitHub release with auto-generated notes
+   (the list of merged pull requests since the previous release).
+
+Everything runs with the workflow's own `GITHUB_TOKEN`; the permissions it
+needs (`contents: write`, `packages: write`) are declared on the job itself
+and override the repository default, so the "Workflow permissions" setting
+can stay read-only.
+
+## What does and does not trigger a release
+
+- A merge touching code, dependencies, the `Dockerfile`, or the workflow:
+  **releases**.
+- A merge touching only documentation or other files outside the paths
+  filter: **does not release** (the pipeline does not run at all).
+- A pushed tag: **does not release itself** — it takes the existing manual
+  tag path (hermetic no-cache build, image published under that tag), and
+  the auto-release job is skipped, so nothing recurses.
+
+## Making a major version bump
+
+Automation only ever bumps the minor. To start a new major, create a
+release for e.g. tag `2.0` manually — either via the GitHub UI ("Draft a
+new release", type the new tag) or `git tag 2.0 && git push origin 2.0`
+plus a release for it. Automation picks it up from there: the next merge
+becomes `2.1`.
+
+## Failure modes
+
+- A run superseded by a newer push to `master` is cancelled; the next
+  successful run self-heals (the version is recomputed from tags, and
+  re-tagging the image is idempotent).
+- Two runs racing for the same version cannot both succeed: creating an
+  existing release fails loudly instead of double-tagging.
+- If tag rulesets are ever added to the repository, `github-actions[bot]`
+  must stay allowed to create `X.Y` tags, or the release job will fail.


### PR DESCRIPTION
## What

This PR makes releases fully automatic. Every merge to `master` that passes
the CI pipeline becomes a release: the latest `X.Y` tag is bumped
(`1.8` → `1.9` → `1.10`), the already-published container image gets the
version tag, and a GitHub release is created with auto-generated notes.

Nothing changes in your workflow as a maintainer: you merge PRs, everything
else happens on its own. There are **no tokens to create, no secrets to add,
no repository settings to change**.

## Why

Right now releasing is a manual step (create a tag, create a release), so
releases happen much more rarely than fixes land on `master`. Users either
run `:latest` or wait. With this change every merged fix is immediately
available as a normal versioned release, with release notes, a matching
`ghcr.io/anatol/pacoloco:<version>` image, and the existing provenance
attestation — at zero ongoing cost.

## How it works

A single new `release` job is appended to the existing `push.yaml`, running
after `merge_and_publish` on master pushes only:

1. **Compute the next version** — take the latest tag matching `X.Y` via the
   GitHub API and bump it by one: `1.8` → `1.9`. The existing scheme is kept
   exactly (two components, no `v` prefix). If a repo has no such tags yet
   (e.g. a fresh fork), it starts at `1.0`.
2. **Tag the image** — `docker buildx imagetools create` adds the version tag
   to the multi-arch manifest that `merge_and_publish` just pushed. The image
   is **not rebuilt**: the version tag points at the same digest as `latest`,
   so the build provenance attestation created earlier in the run still
   applies to it.
3. **Create the release** — `gh release create <version> --generate-notes`
   creates the git tag and the GitHub release with the list of merged PRs
   since the previous release.

The process is documented for humans in `docs/releasing.md`.

## Why no configuration is needed

- The job runs with the workflow's own `GITHUB_TOKEN` and declares the
  permissions it needs (`contents: write` to create the tag/release,
  `packages: write` to tag the image on GHCR) at the job level, which
  overrides the repository default — the "Workflow permissions" setting can
  stay read-only.
- No PAT is needed because nothing relies on the new tag triggering another
  workflow: the image is already built, tested, published and attested by the
  time the tag is created.

## Safety properties

- **No recursion.** The tag is created by `GITHUB_TOKEN`, and such tags do
  not trigger workflows. Manually pushed tags still take the existing
  hermetic tag leg (`[0-9]*`) and explicitly skip the release job.
- **Cancellation-safe.** The workflow's `concurrency` cancels superseded
  branch runs. The image is tagged *before* the release is created, so a
  cancelled run can at worst leave an image tag that the next run overwrites
  — never a released version without an image. The version is recomputed
  from tags on every run, so numbering stays monotonic and self-heals.
- **Race-safe.** If two runs ever race for the same version, creating an
  already-existing release fails loudly instead of double-tagging.
- **Scope-limited.** Merges that only touch documentation don't run the
  pipeline (existing paths filter) and therefore don't produce a release.

## What stays manual

Only one thing, ever: starting a new major. Create a `2.0` release once via
the GitHub UI (or push the tag); automation continues from there with `2.1`.

## Testing

- `actionlint` and `yamllint` are clean.
- The version-bump logic was exercised against the live tags API of this
  repository (`1.8` → `1.9`) and against edge cases: `1.9`/`1.10` ordering
  (`sort -V`), non-matching tags (`v2.0`, `1.9.1`) being ignored, and the
  empty-tag-list fallback.