### PR TITLE
fix: download .db.sig for repositories that sign their databases

### DIFF
--- a/downloader.go
+++ b/downloader.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -27,6 +28,15 @@ var (
 // config.DownloadTimeout is unset (a variable only to allow shortening it
 // in tests).
 var downloadStallTimeout = time.Minute
+
+// errSignatureNotFound reports that an upstream has no signature for a
+// database file. Arch Linux does not sign its repository databases
+// (https://wiki.archlinux.org/title/DeveloperWiki:Repo_DB_Signing), so a
+// missing .db.sig is an expected answer there rather than a failure, and it
+// must not be logged as one. Repositories that do sign their databases
+// (CachyOS, Chaotic-AUR, ALHP, ...) answer with the signature and are
+// downloaded normally.
+var errSignatureNotFound = errors.New("database signature not found upstream")
 
 type Downloader struct {
 	key            string // repoName + path + filename
@@ -84,15 +94,15 @@ func (d *Downloader) download() error {
 		proxyURL, _ = url.Parse(d.repo.HttpProxy)
 	}
 
-	// Archlinux dbs are not signed as of Nov 2024
-	// https://wiki.archlinux.org/title/DeveloperWiki:Repo_DB_Signing
-	if strings.HasSuffix(d.urlPath, ".db.sig") {
-		return nil
-	}
-
 	for _, u := range urls {
 		err := d.downloadFromUpstream(u, proxyURL)
 		if err != nil {
+			if errors.Is(err, errSignatureNotFound) {
+				// The upstream does not publish a signature for this
+				// database. Other mirrors of the same repository will not
+				// either, so stop here and stay quiet.
+				return nil
+			}
 			log.Printf("unable to download file %v: %v", d.key, err)
 			continue // try next mirror
 		}
@@ -170,9 +180,15 @@ func (d *Downloader) downloadFromUpstream(repoURL string, proxyURL *url.URL) err
 		d.eventCond.L.Unlock()
 		// either pacoloco or client has the latest version, no need to redownload it
 		return nil
+	case http.StatusNotFound:
+		// Database signatures are optional: report a missing one as its own
+		// error so the caller can stay quiet instead of treating an unsigned
+		// repository as a broken mirror.
+		if strings.HasSuffix(d.urlPath, ".db.sig") {
+			return errSignatureNotFound
+		}
+		return fmt.Errorf("unable to download url %s, status code is %d", upstreamURL, resp.StatusCode)
 	default:
-		// for most dbs signatures are optional, be quiet if the signature is not found
-		// quiet := resp.StatusCode == http.StatusNotFound && strings.HasSuffix(url, ".db.sig")
 		return fmt.Errorf("unable to download url %s, status code is %d", upstreamURL, resp.StatusCode)
 	}
 

--- a/downloader_test.go
+++ b/downloader_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"math/rand"
 	"net"
 	"net/http"
@@ -512,4 +513,114 @@ func TestRequestedFile(t *testing.T) {
 		require.Equal(t, d.urlPath, f.urlPath())
 		require.Equal(t, d.key, f.key())
 	}
+}
+
+// TestSignedDatabaseSignatureIsRefreshed is a regression test for repositories
+// that do sign their databases (CachyOS, Chaotic-AUR, ALHP, ...). Skipping the
+// .db.sig download outright pinned the cached signature forever while the .db
+// next to it kept being refreshed, so pacman eventually verified a new database
+// against an old signature and failed the sync with
+// "signature from ... is invalid".
+func TestSignedDatabaseSignatureIsRefreshed(t *testing.T) {
+	const staleSignature = "stale signature"
+	const freshSignature = "fresh signature"
+
+	var requested atomic.Int32
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		requested.Add(1)
+		w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+		w.Header().Set("Content-Length", strconv.Itoa(len(freshSignature)))
+		_, _ = w.Write([]byte(freshSignature))
+	}
+	mirror := httptest.NewServer(http.HandlerFunc(handler))
+	defer mirror.Close()
+
+	testDir := t.TempDir()
+	config = &Config{
+		CacheDir:        testDir,
+		Port:            -1,
+		DownloadTimeout: 10,
+		Repos: map[string]*Repo{
+			"signed-repo": {URL: mirror.URL},
+		},
+	}
+
+	// An outdated signature is already cached, as it would be after the
+	// upstream published a new database.
+	cachePath := filepath.Join(testDir, "pkgs", "signed-repo")
+	require.NoError(t, os.MkdirAll(cachePath, os.ModePerm))
+	cachedSig := filepath.Join(cachePath, "test.db.sig")
+	require.NoError(t, os.WriteFile(cachedSig, []byte(staleSignature), os.ModePerm))
+	old := time.Now().Add(-24 * time.Hour)
+	require.NoError(t, os.Chtimes(cachedSig, old, old))
+
+	req := httptest.NewRequest(http.MethodGet, "/repo/signed-repo/test.db.sig", nil)
+	w := httptest.NewRecorder()
+	require.NoError(t, handleRequest(w, req))
+
+	require.Equal(t, int32(1), requested.Load(), "the signature must be re-checked upstream")
+	require.Equal(t, freshSignature, w.Body.String(), "the client must not receive the stale signature")
+
+	onDisk, err := os.ReadFile(cachedSig)
+	require.NoError(t, err)
+	require.Equal(t, freshSignature, string(onDisk), "the cached signature must be updated")
+}
+
+// TestMissingDatabaseSignatureIsQuiet covers the Arch Linux case that motivated
+// skipping signature downloads: its databases are unsigned, so mirrors answer
+// 404 for .db.sig. That is an expected answer and must not be reported as a
+// download failure.
+func TestMissingDatabaseSignatureIsQuiet(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}
+	mirror := httptest.NewServer(http.HandlerFunc(handler))
+	defer mirror.Close()
+
+	testDir := t.TempDir()
+	config = &Config{
+		CacheDir:        testDir,
+		Port:            -1,
+		DownloadTimeout: 10,
+		Repos: map[string]*Repo{
+			"unsigned-repo": {URL: mirror.URL},
+		},
+	}
+
+	var logs strings.Builder
+	previous := log.Writer()
+	log.SetOutput(&logs)
+	defer log.SetOutput(previous)
+
+	req := httptest.NewRequest(http.MethodGet, "/repo/unsigned-repo/core.db.sig", nil)
+	w := httptest.NewRecorder()
+	require.NoError(t, handleRequest(w, req))
+
+	require.Equal(t, http.StatusNotFound, w.Code, "an absent signature stays absent for the client")
+	require.NotContains(t, logs.String(), "unable to download file",
+		"a missing database signature must not be logged as a download failure")
+}
+
+// TestOtherDatabaseNotFoundStillFails pins that only .db.sig gets the quiet
+// treatment: a missing database itself is a real error worth reporting.
+func TestOtherDatabaseNotFoundStillFails(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}
+	mirror := httptest.NewServer(http.HandlerFunc(handler))
+	defer mirror.Close()
+
+	testDir := t.TempDir()
+	config = &Config{
+		CacheDir:        testDir,
+		Port:            -1,
+		DownloadTimeout: 10,
+		Repos: map[string]*Repo{
+			"missing-db-repo": {URL: mirror.URL},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/repo/missing-db-repo/core.db", nil)
+	w := httptest.NewRecorder()
+	require.Error(t, handleRequest(w, req))
 }


### PR DESCRIPTION
Fixes #150.

## The problem

58e3d92 made `download()` return early for **every** `.db.sig`:

```go
// Archlinux dbs are not signed as of Nov 2024
// https://wiki.archlinux.org/title/DeveloperWiki:Repo_DB_Signing
if strings.HasSuffix(d.urlPath, ".db.sig") {
	return nil
}
```

The premise holds for Arch Linux, but the check is not scoped to Arch repositories. For a repository that *does* sign its databases (CachyOS, Chaotic-AUR, ALHP, a private repo used with `SigLevel = DatabaseRequired`) the `.db` is in `forceCheckFiles` and revalidated on every request, while its `.db.sig` is pinned to whatever the cache happens to hold. The next database upstream publishes makes pacman verify a new `.db` against an old `.db.sig`:

```
error: cachyos-extra-v4: signature from "CachyOS <admin@cachyos.org>" is invalid
error: failed to synchronize all databases (unexpected error)
```

It never recovers: `.db.sig` is in `forceCheckFiles`, so a `Downloader` is still created per request, but `download()` returns before `eventMetadataReceived` is set and `getDownloadReader` falls back to the cached file. Deleting the stale signature does not help either — it cannot be re-fetched at all, so pacoloco just starts answering 404 for it.

## The change

Download `.db.sig` like any other file, and give a **404 on a `.db.sig`** its own sentinel error:

```go
case http.StatusNotFound:
	if strings.HasSuffix(d.urlPath, ".db.sig") {
		return errSignatureNotFound
	}
	return fmt.Errorf(...)
```

`download()` turns that into a quiet `nil` and stops rather than falling through to the remaining mirrors — a repository that does not sign its databases answers 404 on all of them, so trying the rest only produces noise.

This keeps what #112 and #87 asked for (no log spam, no hard failure on Arch's unsigned databases) while signatures of signed repositories track their database again. A 404 on anything other than a `.db.sig` keeps failing exactly as before.

## Tests

* `TestSignedDatabaseSignatureIsRefreshed` — a stale signature is cached and the upstream serves a newer one; asserts the upstream is contacted, the client receives the fresh signature and the cache is updated. Fails on the previous code, which never contacts the upstream at all.
* `TestMissingDatabaseSignatureIsQuiet` — the Arch case: the upstream 404s, the client still gets a 404, and nothing is logged as a download failure.
* `TestOtherDatabaseNotFoundStillFails` — a missing `.db` is still a hard error, so the quiet path stays scoped to signatures.

`go test ./...` and `go test -race` pass.
